### PR TITLE
Renaming debug view ("InstructionView") to avoid naming conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -472,7 +472,7 @@
       ],
       "debug": [
         {
-          "id": "InstructionView",
+          "id": "DebugInstructionView",
           "name": "Instructions"
         }
       ]

--- a/src/debugAdapter/instructionsView/instructionView.ts
+++ b/src/debugAdapter/instructionsView/instructionView.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
-import { TreeView, window } from "vscode";
-import { IInstruction } from "../models/IInstruction";
+import {TreeView, window} from "vscode";
+import {IInstruction} from "../models/IInstruction";
 import InstructionDataManager from "./instructionDataManager";
 import InstructionDataProvider from "./instructionDataProvider";
 import InstructionTreeNode from "./instructionTreeNode";
 
-const INSTRUCTION_VIEW_ID = "InstructionView";
+const INSTRUCTION_VIEW_ID = "DebugInstructionView";
 
 export default class InstructionView {
   private view: TreeView<InstructionTreeNode>;
@@ -28,7 +28,7 @@ export default class InstructionView {
   public revealInstruction(instruction: IInstruction) {
     if (this.view.visible) {
       const treeNode = new InstructionTreeNode(undefined, undefined, instruction);
-      this.view.reveal(treeNode, { focus: true, select: true, expand: true });
+      this.view.reveal(treeNode, {focus: true, select: true, expand: true});
     }
   }
 }


### PR DESCRIPTION
Debugging on a Windows VM surfaced the following (addressed by renaming the view).

<img width="443" alt="Screen Shot 2022-03-22 at 11 21 40 AM" src="https://user-images.githubusercontent.com/210755/159547144-60387f07-3b4c-499c-9e0f-f47ff1ec8973.png">

That said, on Windows, with both versions of the extension running, one view (whichever loads second) will still sit there "spinning" which points to a race-condition in terms of querying to see the running networks.

This might be good enough given we don't anticipate users should ever have both running and it now at least it fails a little more gracefully.