### PR TITLE
fix: Preventing possible bug on required apps

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,9 @@ export async function activate(context: ExtensionContext) {
 
   Constants.initialize(context);
   DebuggerConfiguration.initialize(context);
+
+  await required.checkAllApps();
+
   await ContractDB.initialize(AdapterType.IN_MEMORY);
   await InfuraServiceClient.initialize(context.globalState);
   MnemonicRepository.initialize(context.globalState);
@@ -240,8 +243,6 @@ export async function activate(context: ExtensionContext) {
     changeCoreSdkConfigurationListener,
   ];
   context.subscriptions.push(...subscriptions);
-
-  await required.checkAllApps();
 
   Telemetry.sendEvent(Constants.telemetryEvents.extensionActivated);
 }

--- a/src/helpers/required.ts
+++ b/src/helpers/required.ts
@@ -62,7 +62,7 @@ export namespace required {
    * Show Requirements Page
    */
   export async function checkRequiredApps(): Promise<boolean> {
-    return checkApps(...requiredApps);
+    return await checkApps(...requiredApps);
   }
 
   export async function checkApps(...apps: RequiredApps[]): Promise<boolean> {


### PR DESCRIPTION
A new await command was added on `checkApps(...requiredApps);`
The `required.checkAllApps();` was put at the beginning of the extension page, before all the initialize functions