### PR TITLE
fix: workaround for build/deploy commands in explorer view

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,13 +117,13 @@
       },
       {
         "command": "truffle-vscode.buildContracts",
-        "title": "Truffle: Build Contracts",
+        "title": "Build Contracts",
         "category": "Blockchain",
         "icon": "$(run-all)"
       },
       {
         "command": "truffle-vscode.deployContracts",
-        "title": "Truffle: Deploy Contracts",
+        "title": "Deploy Contracts",
         "category": "Blockchain"
       },
       {
@@ -219,13 +219,13 @@
       },
       {
         "command": "truffle-vscode.buildContracts",
-        "title": "Truffle: Build Contracts",
+        "title": "Build Contracts",
         "category": "Truffle",
         "icon": "$(run-all)"
       },
       {
         "command": "truffle-vscode.deployContracts",
-        "title": "Truffle: Deploy Contracts",
+        "title": "Deploy Contracts",
         "category": "Truffle",
         "icon": "$(radio-tower)"
       },
@@ -429,6 +429,11 @@
           "when": "view == truffle-vscode.views.explorer",
           "group": "truffle-0@0"
         },
+        {
+          "command": "truffle-vscode.deployContracts",
+          "when": "view == truffle-vscode.views.explorer",
+          "group": "truffle-0@1"
+        },        
         {
           "command": "truffle-vscode.disconnectProject",
           "when": "view == truffle-vscode.truffle && viewItem == genericproject",

--- a/src/commands/TruffleCommands.ts
+++ b/src/commands/TruffleCommands.ts
@@ -35,6 +35,7 @@ import {
 } from "../services";
 import {Telemetry} from "../TelemetryClient";
 import {NetworkNodeView} from "../ViewItems";
+import {Entry} from "../views/fileExplorer";
 import {ServiceCommands} from "./ServiceCommands";
 
 interface IDeployDestinationItem {
@@ -66,6 +67,9 @@ export namespace TruffleCommands {
       return;
     }
 
+    // Workaround for non URI types. In the future, better to use only Uri as pattern
+    uri = uri ? convertEntryToUri(uri) : uri;
+
     const workspace = await getWorkspace(uri);
 
     await showIgnorableNotification(Constants.statusBarMessages.buildingContracts, async () => {
@@ -76,6 +80,9 @@ export namespace TruffleCommands {
 
   export async function deployContracts(uri?: Uri): Promise<void> {
     Telemetry.sendEvent("TruffleCommands.deployContracts.commandStarted");
+
+    // Workaround for non URI types. In the future, better to use only Uri as pattern
+    uri = uri ? convertEntryToUri(uri) : uri;
 
     const contractFolderPath = uri ? Uri.parse(path.resolve(path.join(uri!.fsPath, ".."))) : undefined;
     TruffleConfiguration.truffleConfigUri = await getWorkspace(contractFolderPath);
@@ -505,4 +512,13 @@ async function getWorkspace(uri?: Uri): Promise<Uri> {
   });
 
   return Uri.parse(command.detail!);
+}
+
+function convertEntryToUri(uri: Uri): Uri {
+  if (uri.fsPath) {
+    return uri;
+  } else {
+    const entry: Entry = JSON.parse(JSON.stringify(uri));
+    return Uri.parse(entry.uri.path);
+  }
 }

--- a/src/views/FileExplorer.ts
+++ b/src/views/FileExplorer.ts
@@ -155,7 +155,7 @@ export class FileStat implements vscode.FileStat {
   }
 }
 
-interface Entry {
+export interface Entry {
   uri: vscode.Uri;
   type: vscode.FileType;
 }


### PR DESCRIPTION
### Title
Bug fix to solve the right click on Explorer view

### Bug

The Explorer Tree Item has been composing by [uri, filetype], once the VSCode Tree Item has been composing only by uri.

### Solution

I've built a parser to solve it as a workaround. If we can create a pattern for all Tree Items, is better. We avoid to change the build / deploy code.

Add-ons:

I've put the deploy command on the right click button on Explorer View. 