### PR TITLE
fix: build/deploy fix for windows

### DIFF
--- a/src/helpers/truffleConfig.ts
+++ b/src/helpers/truffleConfig.ts
@@ -16,6 +16,7 @@ import {getWorkspaceRoot} from "../helpers";
 import {MnemonicRepository} from "../services";
 import {Telemetry} from "../TelemetryClient";
 import {tryExecuteCommandInFork} from "./command";
+import {getPathByPlataform} from "./workspace";
 
 export namespace TruffleConfiguration {
   const notAllowedSymbols = new RegExp(
@@ -120,7 +121,7 @@ export namespace TruffleConfiguration {
   export let truffleConfigUri: Uri;
 
   export function getTruffleConfigUri(): string {
-    const workspaceRoot = truffleConfigUri ? truffleConfigUri.fsPath : getWorkspaceRoot()!;
+    const workspaceRoot = truffleConfigUri ? getPathByPlataform(truffleConfigUri) : getWorkspaceRoot()!;
     const configFilePath = path.join(workspaceRoot, Constants.defaultTruffleConfigFileName);
 
     if (!fs.pathExistsSync(configFilePath)) {

--- a/src/helpers/workspace.ts
+++ b/src/helpers/workspace.ts
@@ -47,6 +47,10 @@ export function isWorkspaceOpen(): boolean {
   return !!(workspace.workspaceFolders && workspace.workspaceFolders[0].uri.fsPath);
 }
 
+export function getPathByPlataform(workspace: Uri): string {
+  return process.platform === "win32" ? `${workspace.scheme}:${workspace.path}` : workspace.fsPath;
+}
+
 async function getWorkspaceFiles(dirPath: string): Promise<TruffleWorkspace[]> {
   const files = glob.sync(`${dirPath}/**/${Constants.defaultTruffleConfigFileName}`, {
     ignore: Constants.workspaceIgnoredFolders,


### PR DESCRIPTION
### Problem

When users tried to run build/deploy, an error occurred: spawn C:\WINDOWS\system32\cmd.exe ENOENT
Issue: https://github.com/trufflesuite/vscode-ext/issues/108

### Solution

The issue was found on windows 11 platform only. It was related to volume mapping. If the user open a project in root, the build/deploy command works fine. But, if it was opened in a mapping volume, the problem occurred. A fix was made and applied for windows platforms only.