### PR TITLE
Edit the required apps page to display the version range of all apps

### DIFF
--- a/resources/welcome/prereqs.html
+++ b/resources/welcome/prereqs.html
@@ -33,7 +33,7 @@
                 <img src="{{root}}/images/NodeLogo.png" />
                 <div class="description">
                   Required version:
-                  <span class="version">^14.0.0</span>
+                  <span class="version">⌃14.0.0 and ⌵17.0.0</span>
                 </div>
                 <a class="spinner" href="https://nodejs.org">
                   <span>Install Node.js</span>
@@ -53,7 +53,7 @@
                 <img src="{{root}}/images/NpmLogo.png" />
                 <div class="description">
                   Required version:
-                  <span class="version">^7.18.1</span>
+                  <span class="version">⌃6.14.15 and ⌵9.0.0</span>
                 </div>
                 <a id="installNpm" class="spinner action" title="Install NPM">
                   <span>Install NPM</span>
@@ -71,7 +71,7 @@
                 <img src="{{root}}/images/TruffleLogo.svg" />
                 <div class="description">
                   Required version:
-                  <span class="version">^5.0.0</span>
+                  <span class="version">⌃5.0.0 and ⌵6.0.0</span>
                 </div>
                 <a
                   id="installTruffle"
@@ -85,7 +85,7 @@
                 <img src="{{root}}/images/GanacheLogo.png" />
                 <div class="description">
                   Required version:
-                  <span class="version">^6.0.0</span>
+                  <span class="version">⌃6.0.0 and ⌵8.0.0</span>
                 </div>
                 <a
                   id="installGanache"


### PR DESCRIPTION
The required apps page displays only the minimum version of apps. To avoid misunderstandings, it might be better to display the maximum version as well.

Issue: https://github.com/trufflesuite/vscode-ext/issues/117