### PR TITLE
fix: hdwallet npm package has updated to truffle/hdwallet-provider

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -16,7 +16,7 @@ export enum RequiredApps {
   python = 'python',
   truffle = 'truffle',
   ganache = 'ganache',
-  hdwalletProvider = 'truffle-hdwallet-provider',
+  hdwalletProvider = '@truffle/hdwallet-provider',
 }
 
 export enum NotificationOptions {
@@ -575,7 +575,7 @@ export class Constants {
     networkIsNotReady: Constants.getNetworkIsNotReadyMessage,
     openButton: 'Open',
     privateKeyWasCopiedToClipboard: 'Private key was copied to clipboard',
-    requiresDependency: 'This project deployment requires the truffle-hdwallet-provider.',
+    requiresDependency: 'This project deployment requires the @truffle/hdwallet-provider.',
     rpcEndpointCopiedToClipboard: 'RPCEndpointAddress copied to clipboard',
     seeDetailsRequirementsPage: 'Please see details on the Requirements Page',
     signInButton: 'Sign In',

--- a/src/helpers/checkTruffleConfigTemplate.js
+++ b/src/helpers/checkTruffleConfigTemplate.js
@@ -4,7 +4,7 @@
 const path = require('path');
 
 try {
-  const hdwalletNodeModulePath = path.join(process.cwd(), 'node_modules', 'truffle-hdwallet-provider');
+  const hdwalletNodeModulePath = path.join(process.cwd(), 'node_modules', '@truffle/hdwallet-provider');
   require(hdwalletNodeModulePath);
   require.cache[require.resolve(hdwalletNodeModulePath)].exports = function HDWallet(...args) {
     this.mnemonic = args[0];

--- a/test/TruffleCommandsTests/testData/truffle-config.js
+++ b/test/TruffleCommandsTests/testData/truffle-config.js
@@ -1,4 +1,4 @@
-// const HDWalletProvider = require('truffle-hdwallet-provider');
+// const HDWalletProvider = require('@truffle/hdwallet-provider');
 // const path = require('path');
 // const fs = require('fs');
 module.exports = {


### PR DESCRIPTION
Debugger doesn't work when using HDWalletProvider in your truffle-config.js

The hdwalletNodeModulePath has updated to @truffle/hdwallet-provider

Issue: https://github.com/trufflesuite/vscode-ext/issues/87