### PR TITLE
fix: contract deployment is not forking networks

### DIFF
--- a/src/Models/IDeployDestination.ts
+++ b/src/Models/IDeployDestination.ts
@@ -3,6 +3,7 @@
 
 import {INetwork} from '@/helpers/ConfigurationReader';
 import {ItemType} from './ItemType';
+import {TLocalProjectOptions} from './TreeItems';
 
 export interface IDeployDestination {
   description?: string;
@@ -12,4 +13,5 @@ export interface IDeployDestination {
   port?: number;
   getTruffleNetwork: () => Promise<INetwork>;
   networkId: number;
+  options?: TLocalProjectOptions;
 }

--- a/src/Models/TreeItems/LocalProject.ts
+++ b/src/Models/TreeItems/LocalProject.ts
@@ -47,6 +47,7 @@ export class LocalProject extends Project {
           networkId: node.networkId,
           networkType: node.itemType,
           port: node.port,
+          options: this.options,
         } as IDeployDestination;
       })
     );


### PR DESCRIPTION
When you try to deploy a contract on a forked network, the system starts it as a standard non-forked network

Related to: https://github.com/trufflesuite/vscode-ext/issues/140