### PR TITLE
Debug only works with Ganache Development Instance

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -618,6 +618,7 @@ export class Constants {
     signInButton: 'Sign In',
     transactionBytecodeWasCopiedToClipboard: 'Transaction Bytecode was copied to clipboard',
     transactionNodeNameValidating: 'Transaction Node name validating...',
+    transactionNotFound: 'No transactions deployed to this network',
     unsupportedVersionOfExternalExtension: (name: string, currentVersion: string, supportedVersion: string) =>
       `You try to use "${name}" extension of version ${currentVersion}, but current supported vesrion is ${supportedVersion}.`,
   };

--- a/src/debugAdapter/constants/truffleConfig.ts
+++ b/src/debugAdapter/constants/truffleConfig.ts
@@ -2,4 +2,3 @@
 // Licensed under the MIT license.
 
 export const TRUFFLE_CONFIG_NAME = 'truffle-config.js';
-export const TRUFFLE_CONFIG_DEBUG_NETWORK_TYPE = 'development';

--- a/src/debugAdapter/contracts/contractsPrepareHelpers.ts
+++ b/src/debugAdapter/contracts/contractsPrepareHelpers.ts
@@ -18,10 +18,10 @@ export type ContractData = {
   lookupMap: Map<string, string>;
 };
 
-export async function prepareContracts(workingDirectory: any): Promise<ContractData> {
+export async function prepareContracts(workingDirectory: any, providerUrl: string): Promise<ContractData> {
   // TODO, the same code in the debuggerCommands.ts, do refactoring
   const debugNetwork = new DebugNetwork(workingDirectory);
-  await debugNetwork.load();
+  await debugNetwork.load(providerUrl);
   const contractBuildDir = debugNetwork.getTruffleConfiguration()!.contracts_build_directory;
   const debugNetworkOptions = debugNetwork.getNetwork()!.options;
   const web3 = new Web3Wrapper(debugNetworkOptions);

--- a/src/debugAdapter/debugNetwork.ts
+++ b/src/debugAdapter/debugNetwork.ts
@@ -132,7 +132,7 @@ export class DebugNetwork {
     } else {
       const items = projects.map((project) => {
         return {
-          label: `$(callstack-view-session) ${project.label}`,
+          label: `$(debug-alt) ${project.label}`,
           detail: project.description,
         } as QuickPickItem;
       });

--- a/src/debugAdapter/debugNetwork.ts
+++ b/src/debugAdapter/debugNetwork.ts
@@ -121,19 +121,14 @@ export class DebugNetwork {
    */
   private async getHost(projects: LocalProject[], providerUrl?: string): Promise<LocalNetworkNode> {
     if (providerUrl) {
-      const project = projects.find((project) => {
-        const network = project.getChildren().at(0) as LocalNetworkNode;
-        const url = `${network.url.protocol}//${network.url.host}`;
-        return url === providerUrl ? project : undefined;
-      });
-
-      if (!project) {
-        const error = new Error(Constants.ganacheCommandStrings.serverNoGanacheAvailable);
-        Telemetry.sendException(error);
-        throw error;
-      }
-
-      return project.getChildren().at(0) as LocalNetworkNode;
+      return projects
+        .find((project) => {
+          const network = project.getChildren().at(0) as LocalNetworkNode;
+          const url = `${network.url.protocol}//${network.url.host}`;
+          return url === providerUrl;
+        })!
+        .getChildren()
+        .at(0) as LocalNetworkNode;
     } else {
       const items = projects.map((project) => {
         return {

--- a/src/debugAdapter/debugSession.ts
+++ b/src/debugAdapter/debugSession.ts
@@ -106,7 +106,7 @@ export class SolidityDebugSession extends LoggingDebugSession {
       logger.setup(args.noDebug ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
 
       // start the program in the runtime
-      await this._runtime.attach(args.txHash, args.workingDirectory);
+      await this._runtime.attach(args.txHash, args.workingDirectory, args.providerUrl);
       await this._runtime.processInitialBreakPoints();
 
       // Events order is important

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -149,8 +149,8 @@ export default class RuntimeInterface extends EventEmitter {
    * @param txHash
    * @param workingDirectory
    */
-  public async attach(txHash: string, workingDirectory: string): Promise<void> {
-    const result = await prepareContracts(workingDirectory);
+  public async attach(txHash: string, workingDirectory: string, providerUrl: string): Promise<void> {
+    const result = await prepareContracts(workingDirectory, providerUrl);
 
     this._deployedContracts = filterContractsWithAddress(result.contracts);
 

--- a/src/debugAdapter/transaction/transactionProvider.ts
+++ b/src/debugAdapter/transaction/transactionProvider.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
+import {Constants} from '@/Constants';
 import {TRANSACTION_NUMBER_TO_SHOW} from '../constants/transaction';
 import {ContractJsonsProvider} from '../contracts/contractJsonsProvider';
 import {groupBy} from '../helpers';
@@ -25,7 +26,14 @@ export class TransactionProvider {
   }
 
   public async getLastTransactionHashes(take: number = TRANSACTION_NUMBER_TO_SHOW): Promise<string[]> {
-    const latestBlockNumber = await this._web3.eth.getBlockNumber();
+    let latestBlockNumber: any;
+
+    try {
+      latestBlockNumber = await this._web3.eth.getBlockNumber();
+    } catch {
+      throw new Error(Constants.informationMessage.transactionNotFound);
+    }
+
     const latestBlock = await this._web3.eth.getBlock(latestBlockNumber);
     const txHashes: string[] = [];
     let block = latestBlock;

--- a/test/debugAdapter/runtimeInterface.test.ts
+++ b/test/debugAdapter/runtimeInterface.test.ts
@@ -99,7 +99,7 @@ const baseSessionMock: truffleDebugger.Session = {
 
 async function initMockRuntime() {
   const runtimeInterface = new RuntimeInterface();
-  await runtimeInterface.attach('', '');
+  await runtimeInterface.attach('', '', '');
   return runtimeInterface;
 }
 


### PR DESCRIPTION
### Problem
Debug transaction is working with Ganache development instance only. If a new Ganache instance is created with another name, and a new contract is sent to it, a Debug attempt causes a system error.

### Solution
A network selector has implemented to allow users choose your network before starting debugging

Refer to: https://github.com/trufflesuite/vscode-ext/issues/141