### PR TITLE
Replace `open` package with `vscode.env.openExternal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -712,7 +712,6 @@
     "hdkey": "^1.1.1",
     "lodash": "4.17.21",
     "mkdirp": "^1.0.4",
-    "open": "^6.4.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "rimraf": "^3.0.2",

--- a/src/services/infuraService/codeFlowLogin.ts
+++ b/src/services/infuraService/codeFlowLogin.ts
@@ -4,10 +4,10 @@
 import crypto from 'crypto';
 import fs from 'fs-extra';
 import http from 'http';
-import open from 'open';
 import querystring from 'querystring';
 import requestPromise from 'request-promise';
 import url from 'url';
+import {env, Uri} from 'vscode';
 import {Constants} from '../../Constants';
 import {Telemetry} from '../../TelemetryClient';
 
@@ -32,7 +32,7 @@ const commonRequestParams = {
   scope: Object.values(Constants.infuraCredentials.scopes).join('+'),
 };
 
-export async function signIn() {
+export async function signIn(): Promise<IToken> {
   const {server, codePromise} = createServer();
 
   try {
@@ -43,7 +43,7 @@ export async function signIn() {
 
     authorizationUrl.search = queryString(authParams);
 
-    await open(authorizationUrl.toString());
+    await env.openExternal(Uri.parse(authorizationUrl.toString()));
 
     const code = await codePromise;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7004,11 +7004,6 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
 is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz"
@@ -8649,13 +8644,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-open@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.npmjs.org/open/-/open-6.4.0.tgz"
-  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
-  dependencies:
-    is-wsl "^1.1.0"
 
 open@^8.0.4:
   version "8.4.0"


### PR DESCRIPTION
This PR uses the recommended way to open external links. See `openExternal` in https://code.visualstudio.com/api/references/vscode-api#env.

Now when the user selects Infura sign-in, a prompt should appear confirming opening the external link https://code.visualstudio.com/updates/v1_38#_link-protection-for-outgoing-links. It partially solves comment https://github.com/trufflesuite/vscode-ext/issues/175#issuecomment-1203896606.

Moreover, it removes the `open` package, since it is not used anymore.
