### PR TITLE
Remove Mocha config from packaged extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,6 +23,7 @@ ui-test/**
 **/*.map
 **/*.ts
 **/webpack.*.js
+**/.mocharc.js
 **/coverconfig.json
 .husky/**
 **/GitVersion.yml


### PR DESCRIPTION
This PR adds an entry for Mocha config (`.mocharc.js`) to `.vscodeignore`, so that it will not be packaged into the extension when issuing `vsce package`.