### PR TITLE
Remove unused `dom` `lib` from `tsconfig`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es6", "dom"],
+    "lib": ["es6"],
     "sourceMap": true,
     "resolveJsonModule": true,
     "baseUrl": "./",


### PR DESCRIPTION
This PR removes the `dom` entry from `lib` in `tsconfig.json`, since it is not needed. The runtime environment for the extension is provide by VS Code, and does not contain the `dom` library.

Moreover, if `dom` is declared, autocompletion assumes that `window` refers to the `dom` and not the VS Code API, which is a bit annoying.

![vscode-ext-1660231278161](https://user-images.githubusercontent.com/4592980/184171159-48283a93-8385-4ace-b999-5afde30d7081.gif)

By removing `dom` from `tsconfig`, autocompletion will use the right `window` namespace from VS Code's API.

![vscode-ext-1660231361202](https://user-images.githubusercontent.com/4592980/184171201-fba9a797-adbe-473c-b038-62b1680f1229.gif)
 