### PR TITLE
Dropdown when selecting a box to "unbox"

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -43,6 +43,7 @@ export class Constants {
     migrations_directory: path.join('./', 'migrations'),
   };
 
+  public static truffleBoxes = 'https://trufflesuite.com/boxes/data.json';
   public static defaultTruffleBox = 'truffle-box/vscode-starter-box';
   public static defaultDebounceTimeout = 300;
   public static defaultInputNameInBdm = 'transaction-node';
@@ -590,6 +591,7 @@ export class Constants {
     VariableShouldBeDefined: Constants.getMessageVariableShouldBeDefined,
     WorkspaceShouldBeOpened: 'Workspace should be opened',
     DashboardVersionError: 'Please upgrade to the latest version of Truffle to use this feature',
+    FetchingBoxesHasFailed: 'An error occurred while fetching boxes',
   };
 
   public static informationMessage = {

--- a/test/commands/ProjectCommand.test.ts
+++ b/test/commands/ProjectCommand.test.ts
@@ -12,6 +12,7 @@ import {required} from '../../src/helpers/required';
 import * as userInteraction from '../../src/helpers/userInteraction';
 import {CancellationEvent} from '../../src/Models';
 import {Output} from '../../src/Output';
+import * as vscode from 'vscode';
 
 describe('ProjectCommands', () => {
   describe('Unit tests', () => {
@@ -250,8 +251,8 @@ describe('ProjectCommands', () => {
       // Arrange
       const projectCommandsRewire = rewire('../../src/commands/ProjectCommands');
       const createProjectFromTruffleBox = projectCommandsRewire.__get__('createProjectFromTruffleBox');
-      projectCommandsRewire.__set__('getTruffleBoxName', sinon.mock().returns(truffleBoxName));
-      const getTruffleBoxNameMock = projectCommandsRewire.__get__('getTruffleBoxName');
+      projectCommandsRewire.__set__('getTruffleUnboxCommand', sinon.mock().returns(truffleBoxName));
+      const getTruffleUnboxCommandMock = projectCommandsRewire.__get__('getTruffleUnboxCommand');
       projectCommandsRewire.__set__('createProject', sinon.mock());
       const createProjectMock = projectCommandsRewire.__get__('createProject');
 
@@ -259,7 +260,7 @@ describe('ProjectCommands', () => {
       await createProjectFromTruffleBox(projectPath);
 
       // Assert
-      assert.strictEqual(getTruffleBoxNameMock.calledOnce, true, 'getTruffleBoxName should be called once');
+      assert.strictEqual(getTruffleUnboxCommandMock.calledOnce, true, 'getTruffleUnboxCommand should be called once');
       assert.strictEqual(createProjectMock.calledOnce, true, 'createProject should be called once');
       assert.strictEqual(
         createProjectMock.args[0][0],
@@ -469,22 +470,24 @@ describe('ProjectCommands', () => {
       });
     });
 
-    it('Method getTruffleBoxName should return a value', async () => {
+    it('Method getTruffleUnboxCommand should return a value', async () => {
       // Arrange
-      const helpersMock = sinon.mock(userInteraction);
-      const testName = 'test';
+      const displayName = 'drizzle';
+      const repoName = 'drizzle-box';
       const projectCommandsRewire = rewire('../../src/commands/ProjectCommands');
-      const getTruffleBoxName = projectCommandsRewire.__get__('getTruffleBoxName');
-      const showInputBoxMock = helpersMock.expects('showInputBox');
+      const getTruffleUnboxCommand = projectCommandsRewire.__get__('getTruffleUnboxCommand');
+      const showQuickPickMock = sinon.stub(vscode.window, 'showQuickPick');
 
-      showInputBoxMock.returns(testName);
+      showQuickPickMock.onCall(0).callsFake((items: any) => {
+        return items.find((item: any) => item.label === displayName);
+      });
 
       // Act
-      const result = await getTruffleBoxName();
+      const result = await getTruffleUnboxCommand();
 
       // Assert
-      assert.strictEqual(result, testName, 'result should be equal to expected string');
-      assert.strictEqual(showInputBoxMock.calledOnce, true, 'showInputBox should be called once');
+      assert.strictEqual(result, repoName, 'result should be equal to expected string');
+      assert.strictEqual(showQuickPickMock.calledOnce, true, 'showQuickPick should be called once');
     });
   });
 
@@ -797,8 +800,8 @@ describe('ProjectCommands', () => {
       sinon.stub(workspace, 'workspaceFolders').value(['1']);
 
       const projectCommandsRewire = rewire('../../src/commands/ProjectCommands');
-      projectCommandsRewire.__set__('getTruffleBoxName', sinon.mock().returns(truffleBoxName));
-      const getTruffleBoxNameMock = projectCommandsRewire.__get__('getTruffleBoxName');
+      projectCommandsRewire.__set__('getTruffleUnboxCommand', sinon.mock().returns(truffleBoxName));
+      const getTruffleUnboxCommandMock = projectCommandsRewire.__get__('getTruffleUnboxCommand');
       const createProjectFromTruffleBox = projectCommandsRewire.__get__('createProjectFromTruffleBox');
 
       showErrorMessageMock.returns(Constants.informationMessage.openButton);
@@ -814,7 +817,7 @@ describe('ProjectCommands', () => {
       assert.strictEqual(checkRequiredAppsMock.calledOnce, true, 'checkRequiredApps should be called once');
       assert.strictEqual(showQuickPickMock.calledOnce, true, 'showQuickPick should be called once');
       assert.strictEqual(gitInitMock.calledOnce, true, 'gitInit should be called once');
-      assert.strictEqual(getTruffleBoxNameMock.calledOnce, true, 'getTruffleBoxName should be called once');
+      assert.strictEqual(getTruffleUnboxCommandMock.calledOnce, true, 'getTruffleUnboxCommand should be called once');
       assert.strictEqual(gitInitMock.args[0][0], firstProjectPath);
       assert.strictEqual(showOpenFolderDialogMock.calledOnce, true, 'showOpenFolderDialog should be called once');
       assert.strictEqual(ensureDirMock.calledOnce, true, 'ensureDir should be called once');
@@ -873,7 +876,7 @@ describe('ProjectCommands', () => {
 
     it(
       'Method createProjectFromTruffleBox get truffleBoxName and create new project with this name. ' +
-        'showInputBox called twice in getTruffleBoxName.',
+        'showInputBox called twice in getTruffleUnboxCommand.',
       async () => {
         // Arrange
         checkRequiredAppsMock.returns(true);
@@ -881,8 +884,8 @@ describe('ProjectCommands', () => {
         executeCommandMock.throws();
 
         const projectCommandsRewire = rewire('../../src/commands/ProjectCommands');
-        projectCommandsRewire.__set__('getTruffleBoxName', sinon.mock().returns(truffleBoxName));
-        const getTruffleBoxNameMock = projectCommandsRewire.__get__('getTruffleBoxName');
+        projectCommandsRewire.__set__('getTruffleUnboxCommand', sinon.mock().returns(truffleBoxName));
+        const getTruffleUnboxCommandMock = projectCommandsRewire.__get__('getTruffleUnboxCommand');
         const createProjectFromTruffleBox = projectCommandsRewire.__get__('createProjectFromTruffleBox');
         showErrorMessageMock.returns(Constants.informationMessage.openButton);
         showQuickPickMock.returns({
@@ -900,7 +903,7 @@ describe('ProjectCommands', () => {
         assert.strictEqual(checkRequiredAppsMock.calledOnce, true, 'checkRequiredApps should be called once');
         assert.strictEqual(showQuickPickMock.calledOnce, true, 'showQuickPick should be called once');
         assert.strictEqual(gitInitMock.notCalled, true, 'gitInit should not be called');
-        assert.strictEqual(getTruffleBoxNameMock.calledOnce, true, 'getTruffleBoxName should be called once');
+        assert.strictEqual(getTruffleUnboxCommandMock.calledOnce, true, 'getTruffleUnboxCommand should be called once');
         assert.strictEqual(showOpenFolderDialogMock.calledOnce, true, 'showOpenFolderDialog should be called once');
         assert.strictEqual(ensureDirMock.calledOnce, true, 'ensureDir should be called once');
         assert.strictEqual(


### PR DESCRIPTION
## PR description

ref: #25

When creating a new project, and choosing the option to "unbox" a "truffle box", the text box that asked the user to write the name of the "box" was replaced by a dropdown which loads all the boxes from the website in real-time.

P.s.: The description of the boxes is done but it still doesn't appear because the file on the website doesn't have the description of the boxes yet

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
