### PR TITLE
Remove redundant txns from dialog after a redeploy

### DIFF
--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -61,8 +61,9 @@ export namespace DebuggerCommands {
 async function getQuickPickItems(txProvider: TransactionProvider) {
   const txHashes = await txProvider.getLastTransactionHashes();
   const txInfos = await txProvider.getTransactionsInfo(txHashes);
+  const lastTxsDeployed = txInfos.filter((tx) => tx.contractName !== '');
 
-  return txInfos.map((txInfo) => {
+  return lastTxsDeployed.map((txInfo) => {
     const label = shortenHash(txInfo.hash);
     const description = generateDescription(txInfo.contractName, txInfo.methodName);
     return {alwaysShow: true, label, description, detail: txInfo.hash} as QuickPickItem;


### PR DESCRIPTION
## PR description

When you redeploy a contract without restarting the network, duplicate transactions show up in the dialog when selecting a txhash via Truffle: Debug Transaction, for example. Note that the "legacy" txns don't include the contract name.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
