### PR TITLE
Create an "auto-deploy on save" toggle in the Contract Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,6 +258,11 @@
         "command": "truffle-vscode.views.dashboard.copyRPCEndpointAddress",
         "title": "Copy RPC Endpoint Address",
         "category": "Truffle"
+      },
+      {
+        "command": "truffle-vscode.contracts.deployOnSave",
+        "title": "Deploy the contract when it is saved",
+        "category": "Truffle"
       }
     ],
     "breakpoints": [
@@ -313,6 +318,10 @@
         {
           "when": "false",
           "command": "truffle-vscode.getGanacheServerInfo"
+        },
+        {
+          "when": "false",
+          "command": "truffle-vscode.contracts.deployOnSave"
         }
       ],
       "view/title": [

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -69,6 +69,34 @@ export class Constants {
     },
   };
 
+  public static contract = {
+    configuration: {
+      statusBar: {
+        text: {
+          on: {
+            label: 'Contract Auto Deploy: ON',
+            message: 'Contract auto deploy has been switched on.',
+          },
+          off: {
+            label: 'Contract Auto Deploy: OFF',
+            message: 'Contract auto deploy has been switched off.',
+          },
+        },
+        command: 'truffle-vscode.contracts.deployOnSave',
+      },
+      extension: {
+        json: '.json',
+        sol: '.sol',
+        txt: '.txt',
+      },
+      properties: {
+        abi: 'abi',
+        bytecode: 'bytecode',
+        deployedBytecode: 'deployedBytecode',
+      },
+    },
+  };
+
   // Values are quite brittle and don't map directly to the requirements.html screen.
   public static requiredVersions: {[key: string]: string | {min: string; max: string}} = {
     [RequiredApps.ganache]: {
@@ -115,6 +143,7 @@ export class Constants {
     isNotifiedAboutOZSdk: 'isNotifiedAboutOZSdk',
     mnemonicStorageKey: 'mnemonicStorage',
     serviceResourceKey: 'treeContent',
+    contractAutoDeployOnSave: 'contractAutoDeployOnSave',
   };
 
   public static infuraFileResponse = {
@@ -150,23 +179,11 @@ export class Constants {
     },
   };
 
-  public static contractExtension = {
-    json: '.json',
-    sol: '.sol',
-    txt: '.txt',
-  };
-
   public static networkProtocols = {
     file: 'file://',
     ftp: 'ftp://',
     http: 'http://',
     https: 'https://',
-  };
-
-  public static contractProperties = {
-    abi: 'abi',
-    bytecode: 'bytecode',
-    deployedBytecode: 'deployedBytecode',
   };
 
   public static propertyLabels = {
@@ -346,7 +363,7 @@ export class Constants {
     },
     hasDigits: /(?=.*\d)/g,
     infuraProjectname: /^([a-zA-Z]|\d|\s|[-_:]){3,}$/g,
-    isJsonFile: new RegExp(Constants.contractExtension.json + '$'),
+    isJsonFile: new RegExp(Constants.contract.configuration.extension.json + '$'),
     isLowerCase: /^[a-z0-9_\-!@$^&()+=?/<>|[\]{}:.\\~ #`*"'%;,]+$/g,
     isUrl: /^(?:http(s)?:\/\/)?[\w:@.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+$/gim,
     lowerCaseLetter: /(?=.*[a-z]).*/g,

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -73,15 +73,10 @@ export class Constants {
     configuration: {
       statusBar: {
         text: {
-          on: {
-            label: 'Contract Auto Deploy: ON',
-            message: 'Contract auto deploy has been switched on.',
-          },
-          off: {
-            label: 'Contract Auto Deploy: OFF',
-            message: 'Contract auto deploy has been switched off.',
-          },
+          enabled: 'Contract Auto Deploy: ON',
+          disabled: 'Contract Auto Deploy: OFF',
         },
+        tooltip: 'Turn on/off automatic deployment when saving .sol files',
         command: 'truffle-vscode.contracts.deployOnSave',
       },
       extension: {

--- a/src/Models/StatusBarItems/Contract.ts
+++ b/src/Models/StatusBarItems/Contract.ts
@@ -1,0 +1,84 @@
+import {Constants} from '@/Constants';
+import {Memento, StatusBarAlignment, StatusBarItem, window} from 'vscode';
+
+export namespace StatusBarItems {
+  export class Contract {
+    /**
+     * The status bar item object.
+     */
+    private _statusBar: StatusBarItem;
+
+    /**
+     * Starts the status bar item.
+     *
+     * @param _globalState A memento represents a storage utility. It can store and retrieve values.
+     */
+    constructor(private readonly _globalState: Memento) {
+      this._statusBar = window.createStatusBarItem(StatusBarAlignment.Left);
+
+      this.bind();
+    }
+
+    /**
+     * This method is responsible for loading status bar item settings as well as checking the current state.
+     */
+    private bind(): void {
+      // Gets the current state (enebled or disabled)
+      const isEnabled = this.getState();
+
+      // Sets the status bar item configuration
+      this._statusBar.text = this.getText(isEnabled);
+      this._statusBar.command = Constants.contract.configuration.statusBar.command;
+      this._statusBar.tooltip = Constants.contract.configuration.statusBar.tooltip;
+      this._statusBar.show();
+    }
+
+    /**
+     * This function is responsible for returning the text that should be displayed in the status bar item.
+     *
+     * @param isEnabled The flag that indicates whether the text should display the label for enabled or disabled.
+     * @returns The chosen text.
+     */
+    private getText(isEnabled: boolean): string {
+      // Returns the status bar label according to the flag value
+      return isEnabled
+        ? Constants.contract.configuration.statusBar.text.enabled
+        : Constants.contract.configuration.statusBar.text.disabled;
+    }
+
+    /**
+     * This function is responsible for updating the current status of the status bar item.
+     *
+     * @param isEnabled The flag that indicates whether auto deploy should be enabled or disabled.
+     */
+    private updateState(isEnabled: boolean): void {
+      // Updates the state
+      this._globalState.update(Constants.globalStateKeys.contractAutoDeployOnSave, isEnabled);
+    }
+
+    /**
+     * This function is responsible for returning the current status of the status bar item.
+     * Whether automatic deployment is enabled or disabled.
+     *
+     * @returns The state value for enabled / disabled.
+     */
+    public getState(): boolean {
+      // Gets the current state
+      return this._globalState.get<boolean>(Constants.globalStateKeys.contractAutoDeployOnSave) || false;
+    }
+
+    /**
+     * This function is responsible for setting the current status of the status bar item,
+     * its correct label as well as updating the state.
+     *
+     * @param isEnabled The flag that indicates whether auto deploy should be enabled or disabled.
+     */
+    public setState(isEnabled: boolean): void {
+      // Gets the status bar label according to the flag value
+      this._statusBar.text = this.getText(isEnabled);
+
+      // Updates the state
+      this.updateState(isEnabled);
+    }
+  }
+}

--- a/src/commands/ContractCommands.ts
+++ b/src/commands/ContractCommands.ts
@@ -1,121 +1,67 @@
 // Copyright (c) Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
-import {
-  commands,
-  ExtensionContext,
-  StatusBarAlignment,
-  StatusBarItem,
-  TextDocument,
-  Uri,
-  window,
-  Memento,
-} from 'vscode';
+import {StatusBarItems} from '@/Models/StatusBarItems/Contract';
+import {commands, ExtensionContext, Uri, window} from 'vscode';
 import {Constants} from '../Constants';
 import {CancellationEvent} from '../Models';
 import {ContractUI} from '../pages/ContractUI';
 import {ContractDB, ContractService} from '../services';
 import {Telemetry} from '../TelemetryClient';
-import {TruffleCommands} from './TruffleCommands';
 
 export namespace ContractCommands {
-  export class Contract {
-    private _globalState: Memento;
-    private _statusBar: StatusBarItem;
-    private _autoDeployState: boolean;
+  /**
+   * This function is responsible for enabling or disabling the automatic deployment of contracts
+   *
+   * @param contractStatusBarItem The object representing the status bar contract item.
+   */
+  export async function setEnableOrDisableAutoDeploy(contractStatusBarItem: StatusBarItems.Contract): Promise<void> {
+    // Gets the current auto deploy current state and invert its value
+    const enableOrDisableAutoDeploy = contractStatusBarItem.getState() ? false : true;
 
-    constructor(private readonly _context: ExtensionContext) {
-      this._globalState = this._context.globalState;
-      this._statusBar = window.createStatusBarItem(StatusBarAlignment.Left);
-      this._autoDeployState =
-        this._globalState.get<boolean>(Constants.globalStateKeys.contractAutoDeployOnSave) || false;
-    }
+    // Set the new state value
+    contractStatusBarItem.setState(enableOrDisableAutoDeploy);
+  }
 
-    private async setStatusBarItem(silently: boolean): Promise<void> {
-      if (this._autoDeployState) {
-        this._statusBar.text = Constants.contract.configuration.statusBar.text.on.label;
-        if (!silently) window.showInformationMessage(Constants.contract.configuration.statusBar.text.on.message);
+  /**
+   * @deprecated The method should not be used
+   */
+  export async function showSmartContractPage(context: ExtensionContext, uri: Uri): Promise<void> {
+    Telemetry.sendEvent('ContractCommands.showSmartContract.commandStarted');
+    const contractName = ContractService.getContractNameBySolidityFile(uri.fsPath);
+
+    let contractHistory = await ContractDB.getContractInstances(contractName);
+
+    // First attempt
+    if (!contractHistory.length) {
+      Telemetry.sendEvent('ContractCommands.showSmartContract.needUserAction');
+      const result = await window.showWarningMessage(
+        Constants.informationMessage.contractNotDeployed,
+        Constants.informationMessage.deployButton,
+        Constants.informationMessage.cancelButton
+      );
+
+      if (result === Constants.informationMessage.deployButton) {
+        Telemetry.sendEvent('ContractCommands.showSmartContract.deployContracts');
+        await commands.executeCommand('truffle-vscode.deployContracts');
       } else {
-        this._statusBar.text = Constants.contract.configuration.statusBar.text.off.label;
-        if (!silently) window.showInformationMessage(Constants.contract.configuration.statusBar.text.off.message);
-      }
-    }
-
-    public async initializeStatusBarItem(): Promise<void> {
-      this._statusBar.command = Constants.contract.configuration.statusBar.command;
-      this._statusBar.show();
-
-      await this.setStatusBarItem(true);
-    }
-
-    public async switchAutoDeployOnOff(silently: boolean): Promise<void> {
-      this._autoDeployState = this._autoDeployState ? false : true;
-
-      await this.setStatusBarItem(silently);
-
-      this._globalState.update(Constants.globalStateKeys.contractAutoDeployOnSave, this._autoDeployState);
-    }
-
-    public async showSmartContractPage(uri: Uri): Promise<void> {
-      Telemetry.sendEvent('ContractCommands.showSmartContract.commandStarted');
-      const contractName = ContractService.getContractNameBySolidityFile(uri.fsPath);
-
-      let contractHistory = await ContractDB.getContractInstances(contractName);
-
-      // First attempt
-      if (!contractHistory.length) {
-        Telemetry.sendEvent('ContractCommands.showSmartContract.needUserAction');
-        const result = await window.showWarningMessage(
-          Constants.informationMessage.contractNotDeployed,
-          Constants.informationMessage.deployButton,
-          Constants.informationMessage.cancelButton
-        );
-
-        if (result === Constants.informationMessage.deployButton) {
-          Telemetry.sendEvent('ContractCommands.showSmartContract.deployContracts');
-          await commands.executeCommand('truffle-vscode.deployContracts');
-        } else {
-          Telemetry.sendEvent('ContractCommands.showSmartContract.userCancellation');
-          throw new CancellationEvent();
-        }
-
-        contractHistory = await ContractDB.getContractInstances(contractName);
+        Telemetry.sendEvent('ContractCommands.showSmartContract.userCancellation');
+        throw new CancellationEvent();
       }
 
-      // Second attempt after deploy
-      if (!contractHistory.length) {
-        const error = new Error(Constants.errorMessageStrings.CompiledContractIsMissing);
-        Telemetry.sendException(error);
-        throw error;
-      }
-
-      const contractPage = new ContractUI(this._context, contractName);
-
-      await contractPage.show();
-      Telemetry.sendEvent('ContractCommands.showSmartContract.commandFinished');
+      contractHistory = await ContractDB.getContractInstances(contractName);
     }
-  }
 
-  export async function autoDeployContracts(context: ExtensionContext, document: TextDocument): Promise<void> {
-    const globalState: Memento = context.globalState;
-    const contractAutoDeployOnSave = globalState.get<boolean>(Constants.globalStateKeys.contractAutoDeployOnSave);
+    // Second attempt after deploy
+    if (!contractHistory.length) {
+      const error = new Error(Constants.errorMessageStrings.CompiledContractIsMissing);
+      Telemetry.sendException(error);
+      throw error;
+    }
 
-    if (!contractAutoDeployOnSave) return;
+    const contractPage = new ContractUI(context, contractName);
 
-    const file = Uri.parse(document.fileName);
-    await TruffleCommands.deployContracts(file);
-  }
-
-  export async function deployContractOnSave(context: ExtensionContext): Promise<void> {
-    const contract = new ContractCommands.Contract(context);
-
-    await contract.initializeStatusBarItem();
-
-    // Registers the command responsible for disposing the tabs
-    context.subscriptions.push(
-      commands.registerCommand(Constants.contract.configuration.statusBar.command, async () => {
-        await contract.switchAutoDeployOnOff(true);
-      })
-    );
+    await contractPage.show();
+    Telemetry.sendEvent('ContractCommands.showSmartContract.commandFinished');
   }
 }

--- a/src/commands/ContractCommands.ts
+++ b/src/commands/ContractCommands.ts
@@ -1,50 +1,121 @@
 // Copyright (c) Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
-import {commands, ExtensionContext, Uri, window} from 'vscode';
+import {
+  commands,
+  ExtensionContext,
+  StatusBarAlignment,
+  StatusBarItem,
+  TextDocument,
+  Uri,
+  window,
+  Memento,
+} from 'vscode';
 import {Constants} from '../Constants';
 import {CancellationEvent} from '../Models';
 import {ContractUI} from '../pages/ContractUI';
 import {ContractDB, ContractService} from '../services';
 import {Telemetry} from '../TelemetryClient';
+import {TruffleCommands} from './TruffleCommands';
 
 export namespace ContractCommands {
-  export async function showSmartContractPage(context: ExtensionContext, uri: Uri): Promise<void> {
-    Telemetry.sendEvent('ContractCommands.showSmartContract.commandStarted');
-    const contractName = ContractService.getContractNameBySolidityFile(uri.fsPath);
+  export class Contract {
+    private _globalState: Memento;
+    private _statusBar: StatusBarItem;
+    private _autoDeployState: boolean;
 
-    let contractHistory = await ContractDB.getContractInstances(contractName);
+    constructor(private readonly _context: ExtensionContext) {
+      this._globalState = this._context.globalState;
+      this._statusBar = window.createStatusBarItem(StatusBarAlignment.Left);
+      this._autoDeployState =
+        this._globalState.get<boolean>(Constants.globalStateKeys.contractAutoDeployOnSave) || false;
+    }
 
-    // First attempt
-    if (!contractHistory.length) {
-      Telemetry.sendEvent('ContractCommands.showSmartContract.needUserAction');
-      const result = await window.showWarningMessage(
-        Constants.informationMessage.contractNotDeployed,
-        Constants.informationMessage.deployButton,
-        Constants.informationMessage.cancelButton
-      );
-
-      if (result === Constants.informationMessage.deployButton) {
-        Telemetry.sendEvent('ContractCommands.showSmartContract.deployContracts');
-        await commands.executeCommand('truffle-vscode.deployContracts');
+    private async setStatusBarItem(silently: boolean): Promise<void> {
+      if (this._autoDeployState) {
+        this._statusBar.text = Constants.contract.configuration.statusBar.text.on.label;
+        if (!silently) window.showInformationMessage(Constants.contract.configuration.statusBar.text.on.message);
       } else {
-        Telemetry.sendEvent('ContractCommands.showSmartContract.userCancellation');
-        throw new CancellationEvent();
+        this._statusBar.text = Constants.contract.configuration.statusBar.text.off.label;
+        if (!silently) window.showInformationMessage(Constants.contract.configuration.statusBar.text.off.message);
+      }
+    }
+
+    public async initializeStatusBarItem(): Promise<void> {
+      this._statusBar.command = Constants.contract.configuration.statusBar.command;
+      this._statusBar.show();
+
+      await this.setStatusBarItem(true);
+    }
+
+    public async switchAutoDeployOnOff(silently: boolean): Promise<void> {
+      this._autoDeployState = this._autoDeployState ? false : true;
+
+      await this.setStatusBarItem(silently);
+
+      this._globalState.update(Constants.globalStateKeys.contractAutoDeployOnSave, this._autoDeployState);
+    }
+
+    public async showSmartContractPage(uri: Uri): Promise<void> {
+      Telemetry.sendEvent('ContractCommands.showSmartContract.commandStarted');
+      const contractName = ContractService.getContractNameBySolidityFile(uri.fsPath);
+
+      let contractHistory = await ContractDB.getContractInstances(contractName);
+
+      // First attempt
+      if (!contractHistory.length) {
+        Telemetry.sendEvent('ContractCommands.showSmartContract.needUserAction');
+        const result = await window.showWarningMessage(
+          Constants.informationMessage.contractNotDeployed,
+          Constants.informationMessage.deployButton,
+          Constants.informationMessage.cancelButton
+        );
+
+        if (result === Constants.informationMessage.deployButton) {
+          Telemetry.sendEvent('ContractCommands.showSmartContract.deployContracts');
+          await commands.executeCommand('truffle-vscode.deployContracts');
+        } else {
+          Telemetry.sendEvent('ContractCommands.showSmartContract.userCancellation');
+          throw new CancellationEvent();
+        }
+
+        contractHistory = await ContractDB.getContractInstances(contractName);
       }
 
-      contractHistory = await ContractDB.getContractInstances(contractName);
+      // Second attempt after deploy
+      if (!contractHistory.length) {
+        const error = new Error(Constants.errorMessageStrings.CompiledContractIsMissing);
+        Telemetry.sendException(error);
+        throw error;
+      }
+
+      const contractPage = new ContractUI(this._context, contractName);
+
+      await contractPage.show();
+      Telemetry.sendEvent('ContractCommands.showSmartContract.commandFinished');
     }
+  }
 
-    // Second attempt after deploy
-    if (!contractHistory.length) {
-      const error = new Error(Constants.errorMessageStrings.CompiledContractIsMissing);
-      Telemetry.sendException(error);
-      throw error;
-    }
+  export async function autoDeployContracts(context: ExtensionContext, document: TextDocument): Promise<void> {
+    const globalState: Memento = context.globalState;
+    const contractAutoDeployOnSave = globalState.get<boolean>(Constants.globalStateKeys.contractAutoDeployOnSave);
 
-    const contractPage = new ContractUI(context, contractName);
+    if (!contractAutoDeployOnSave) return;
 
-    await contractPage.show();
-    Telemetry.sendEvent('ContractCommands.showSmartContract.commandFinished');
+    const file = Uri.parse(document.fileName);
+    await TruffleCommands.deployContracts(file);
+  }
+
+  export async function deployContractOnSave(context: ExtensionContext): Promise<void> {
+    const contract = new ContractCommands.Contract(context);
+
+    await contract.initializeStatusBarItem();
+
+    // Registers the command responsible for disposing the tabs
+    context.subscriptions.push(
+      commands.registerCommand(Constants.contract.configuration.statusBar.command, async () => {
+        await contract.switchAutoDeployOnOff(true);
+      })
+    );
   }
 }

--- a/src/commands/TruffleCommands.ts
+++ b/src/commands/TruffleCommands.ts
@@ -132,7 +132,7 @@ export namespace TruffleCommands {
     Telemetry.sendEvent('TruffleCommands.writeAbiToBuffer.commandStarted');
     const contract = await readCompiledContract(uri);
 
-    await vscodeEnvironment.writeToClipboard(JSON.stringify(contract[Constants.contractProperties.abi]));
+    await vscodeEnvironment.writeToClipboard(JSON.stringify(contract[Constants.contract.configuration.properties.abi]));
     Telemetry.sendEvent('TruffleCommands.writeAbiToBuffer.commandFinished');
   }
 
@@ -140,7 +140,7 @@ export namespace TruffleCommands {
     Telemetry.sendEvent('TruffleCommands.writeBytecodeToBuffer.commandStarted');
     const contract = await readCompiledContract(uri);
 
-    await vscodeEnvironment.writeToClipboard(contract[Constants.contractProperties.bytecode]);
+    await vscodeEnvironment.writeToClipboard(contract[Constants.contract.configuration.properties.bytecode]);
     Telemetry.sendEvent('TruffleCommands.writeBytecodeToBuffer.commandFinished');
   }
 
@@ -150,7 +150,7 @@ export namespace TruffleCommands {
     ensureFileIsContractJson(uri.fsPath);
 
     const contractInstances = (await ContractDB.getContractInstances(
-      path.basename(uri.fsPath, Constants.contractExtension.json)
+      path.basename(uri.fsPath, Constants.contract.configuration.extension.json)
     )) as ContractInstanceWithMetadata[];
     const contractInstancesWithNetworkInfo = contractInstances.filter((contractIns) => {
       return contractIns.network.name !== undefined && !!contractIns.provider && !!contractIns.address;
@@ -568,7 +568,7 @@ async function readCompiledContract(uri: Uri): Promise<any> {
 }
 
 function ensureFileIsContractJson(filePath: string) {
-  if (path.extname(filePath) !== Constants.contractExtension.json) {
+  if (path.extname(filePath) !== Constants.contract.configuration.extension.json) {
     const error = new Error(Constants.errorMessageStrings.InvalidContract);
     Telemetry.sendException(error);
     throw error;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,7 @@ import {registerHelpView} from './views/HelpView';
 import {OpenUrlTreeItem} from './views/lib/OpenUrlTreeItem';
 import {registerGanacheDetails} from './pages/GanacheDetails';
 import {registerLogView} from './views/LogView';
+import {autoDeploySolidityFiles} from './helpers/workspace';
 
 export async function activate(context: ExtensionContext) {
   /**
@@ -81,6 +82,8 @@ export async function activate(context: ExtensionContext) {
   //#endregion
 
   registerCommand('truffle-vscode.openUrl', (node: OpenUrlTreeItem) => node.openUrl());
+
+  autoDeploySolidityFiles(true);
 
   //#region trufflesuite extension commands
   const refresh = commands.registerCommand('truffle-vscode.refresh', (element) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
   ServiceCommands,
   TruffleCommands,
   GenericCommands,
+  ContractCommands,
 } from './commands';
 import {Constants} from './Constants';
 
@@ -37,7 +38,7 @@ import {registerHelpView} from './views/HelpView';
 import {OpenUrlTreeItem} from './views/lib/OpenUrlTreeItem';
 import {registerGanacheDetails} from './pages/GanacheDetails';
 import {registerLogView} from './views/LogView';
-import {autoDeploySolidityFiles} from './helpers/workspace';
+import {onDidSaveTextDocument} from './helpers/workspace';
 
 export async function activate(context: ExtensionContext) {
   /**
@@ -79,11 +80,12 @@ export async function activate(context: ExtensionContext) {
   await changelogPage.checkAndShow();
 
   await registerGanacheDetails(context);
+
+  await onDidSaveTextDocument(context);
+  await ContractCommands.deployContractOnSave(context);
   //#endregion
 
   registerCommand('truffle-vscode.openUrl', (node: OpenUrlTreeItem) => node.openUrl());
-
-  autoDeploySolidityFiles(true);
 
   //#region trufflesuite extension commands
   const refresh = commands.registerCommand('truffle-vscode.refresh', (element) => {
@@ -217,6 +219,7 @@ export async function activate(context: ExtensionContext) {
       await sdkCoreCommands.initialize(context.globalState);
     }
   });
+
   //#endregion
 
   // #region truffle views

--- a/src/helpers/workspace.ts
+++ b/src/helpers/workspace.ts
@@ -7,6 +7,7 @@ import {Telemetry} from '@/TelemetryClient';
 import * as path from 'path';
 import glob from 'glob';
 import {showQuickPick} from '@/helpers/userInteraction';
+import {TruffleCommands} from '@/commands';
 
 /**
  * The [glob](https://github.com/isaacs/node-glob#glob-primer) pattern to match Truffle config file names.
@@ -140,6 +141,17 @@ export async function getAllTruffleWorkspaces(): Promise<TruffleWorkspace[]> {
   );
 
   return workspaces;
+}
+
+export async function autoDeploySolidityFiles(toggleOnOff: boolean): Promise<void> {
+  if (toggleOnOff) {
+    workspace.onDidSaveTextDocument(async (e) => {
+      const file = Uri.parse(e.fileName);
+      await TruffleCommands.deployContracts(file);
+    });
+  } else {
+    workspace.onDidSaveTextDocument(() => undefined);
+  }
 }
 
 /**

--- a/src/services/contract/ContractService.ts
+++ b/src/services/contract/ContractService.ts
@@ -14,7 +14,7 @@ export namespace ContractService {
   type PathDirectoryKey = 'contracts_directory' | 'migrations_directory' | 'contracts_build_directory';
 
   export function getContractNameBySolidityFile(solidityFilePath: string): string {
-    return path.basename(solidityFilePath, Constants.contractExtension.sol);
+    return path.basename(solidityFilePath, Constants.contract.configuration.extension.sol);
   }
 
   export async function getCompiledContractsMetadata(): Promise<Contract[]> {
@@ -81,7 +81,7 @@ export namespace ContractService {
 
     return fs
       .readdirSync(buildDir)
-      .filter((file) => path.extname(file) === Constants.contractExtension.json)
+      .filter((file) => path.extname(file) === Constants.contract.configuration.extension.json)
       .map((file) => path.join(buildDir, file))
       .filter((file) => fs.lstatSync(file).isFile());
   }

--- a/test/TruffleCommandsTests/WriteToBuffer.test.ts
+++ b/test/TruffleCommandsTests/WriteToBuffer.test.ts
@@ -26,7 +26,7 @@ describe('TruffleCommands - Write To Buffer', () => {
 
       it('writeBytecodeToBuffer should write correct bytecode to clipboard', async () => {
         // Arrange
-        const testBytecode = testJsonString[Constants.contractProperties.bytecode];
+        const testBytecode = testJsonString[Constants.contract.configuration.properties.bytecode];
 
         // Act
         await TruffleCommands.writeBytecodeToBuffer(fileUri);
@@ -41,7 +41,7 @@ describe('TruffleCommands - Write To Buffer', () => {
 
       it('writeAbiToBuffer should write correct abi to clipboard', async () => {
         // Arrange
-        const testAbi = JSON.stringify(testJsonString[Constants.contractProperties.abi]);
+        const testAbi = JSON.stringify(testJsonString[Constants.contract.configuration.properties.abi]);
 
         // Act
         await TruffleCommands.writeAbiToBuffer(fileUri);


### PR DESCRIPTION
## PR description

ref: #211

The automatic deploy functionality for contracts was developed and implemented as a status bar item.

![xpto-1663174615528](https://user-images.githubusercontent.com/32708942/190216923-cf827d7a-8cab-4214-9985-b35b3f57403e.gif)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
