### PR TITLE
fix: auto focus from log panel has been removed

### DIFF
--- a/src/views/LogView.ts
+++ b/src/views/LogView.ts
@@ -75,9 +75,6 @@ export class LogView implements WebviewViewProvider {
    * @param description - represents the log description
    */
   public async createLog(label: OutputLabel, message: string, description?: string): Promise<void> {
-    // Displays the log panel. Unfortunately it doesn't load immediately so we have to wait for the html to load
-    this._view?.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
-
     // Checks if the log panel has already been loaded and is visible
     if (this._view == null || this._view?.visible === false) {
       // If it has not yet been loaded, save the log to be executed after loading the log panel

--- a/test/commands/ProjectCommand.test.ts
+++ b/test/commands/ProjectCommand.test.ts
@@ -709,8 +709,8 @@ describe('ProjectCommands', () => {
 
     it('Method getTruffleUnboxCommand should return a value', async () => {
       // Arrange
-      const displayName = 'drizzle';
-      const repoName = 'drizzle-box';
+      const displayName = 'pet-shop';
+      const repoName = 'pet-shop-box';
       const projectCommandsRewire = rewire('../../src/commands/ProjectCommands');
       const getTruffleUnboxCommand = projectCommandsRewire.__get__('getTruffleUnboxCommand');
       const showQuickPickMock = sinon.stub(vscode.window, 'showQuickPick');


### PR DESCRIPTION
## PR description

ref: #232

@kevinbluer I've just removed the truffle tab auto-focus. Sorry, it was an untested lapse at the moment.

Thank you

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
