### PR TITLE
Temporarily continue logging to the Truffle for VS Code output channel

### DIFF
--- a/src/Output.ts
+++ b/src/Output.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
-import {commands} from 'vscode';
+import {commands, ExtensionContext, window} from 'vscode';
 import {LogView} from './views/LogView';
 
 export enum OutputLabel {
@@ -16,6 +16,8 @@ export enum OutputLabel {
 }
 
 export class Output {
+  private static readonly _outputChannel = window.createOutputChannel(OutputLabel.truffleForVSCode);
+
   /**
    * Append the given value and a line feed character
    * to the log panel
@@ -26,6 +28,9 @@ export class Output {
    */
   public static outputLine(label: OutputLabel, message: string, description?: string): void {
     commands.executeCommand(`${LogView.viewType}.create.log`, label, this.formatMessage(label, message), description);
+
+    // INFO: THIS IS THE OLD VERSION OF LOGGER USING OUTPUT CHANNELS
+    this._outputChannel.appendLine(this.formatMessage(label, message));
   }
 
   /**
@@ -46,5 +51,13 @@ export class Output {
    */
   private static formatMessage(label = '', message = ''): string {
     return `${label ? `[${label}] ` : ''}${message}`;
+  }
+
+  /**
+   * INFO: THIS IS THE OLD VERSION OF LOGGER USING OUTPUT CHANNELS
+   * Call this only once to push the outputChannel into the list of subscriptions.
+   */
+  public static init(context: ExtensionContext) {
+    context.subscriptions.push(this._outputChannel);
   }
 }

--- a/src/Output.ts
+++ b/src/Output.ts
@@ -39,7 +39,7 @@ export class Output {
    * @param label - represents the log type
    * @param description - represents the log description
    */
-  public static dispose(label: OutputLabel, description?: string): void {
+  public static async dispose(label: OutputLabel, description?: string): Promise<void> {
     commands.executeCommand(`${LogView.viewType}.dispose.tab`, label, description);
   }
 
@@ -59,6 +59,13 @@ export class Output {
    */
   public static init(context: ExtensionContext) {
     context.subscriptions.push(this._outputChannel);
+  }
+
+  public static show(): void {
     this._outputChannel.show();
+  }
+
+  public static hide(): void {
+    this._outputChannel.hide();
   }
 }

--- a/src/Output.ts
+++ b/src/Output.ts
@@ -59,5 +59,6 @@ export class Output {
    */
   public static init(context: ExtensionContext) {
     context.subscriptions.push(this._outputChannel);
+    this._outputChannel.show();
   }
 }

--- a/src/commands/TruffleCommands.ts
+++ b/src/commands/TruffleCommands.ts
@@ -77,6 +77,9 @@ export namespace TruffleCommands {
     }
 
     await showIgnorableNotification(Constants.statusBarMessages.buildingContracts, async () => {
+      // INFO: THIS IS THE OLD VERSION OF LOGGER USING OUTPUT CHANNELS
+      Output.show();
+
       await outputCommandHelper.executeCommand(contractDirectory, 'npx', args.join(' '));
       commands.executeCommand('truffle-vscode.views.deployments.refresh');
 
@@ -508,6 +511,9 @@ async function deployToNetwork(networkName: string, truffleConfigPath: string): 
     const workspaceRoot = path.dirname(truffleConfigPath);
     const truffleConfigName = path.basename(truffleConfigPath);
     await fs.ensureDir(workspaceRoot);
+
+    // INFO: THIS IS THE OLD VERSION OF LOGGER USING OUTPUT CHANNELS
+    Output.show();
 
     try {
       await installRequiredDependencies();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import {registerGanacheDetails} from './pages/GanacheDetails';
 import {registerLogView} from './views/LogView';
 import {saveTextDocument} from './helpers/workspace';
 import {StatusBarItems} from './Models/StatusBarItems/Contract';
+import {Output} from './Output';
 
 export async function activate(context: ExtensionContext) {
   /**
@@ -57,6 +58,9 @@ export async function activate(context: ExtensionContext) {
   }
 
   Constants.initialize(context); // still do this first.
+
+  // INFO: THIS IS THE OLD VERSION OF LOGGER USING OUTPUT CHANNELS
+  Output.init(context);
 
   DebuggerConfiguration.initialize(context);
 

--- a/src/services/ganache/GanacheService.ts
+++ b/src/services/ganache/GanacheService.ts
@@ -62,7 +62,7 @@ export namespace GanacheService {
 
     if (portStatus === PortStatus.GANACHE) {
       const pid = await findPid(port);
-      ganacheProcesses[port] = {pid, port};
+      ganacheProcesses[port] = ganacheProcesses[port] ? ganacheProcesses[port] : {pid, port};
     }
 
     if (portStatus === PortStatus.FREE) {
@@ -122,6 +122,7 @@ export namespace GanacheService {
     } catch (error) {
       Telemetry.sendException(error as Error);
       await stopGanacheProcess(ganacheProcess, true);
+      await Output.dispose(OutputLabel.ganacheCommands, port.toString());
       throw error;
     }
 
@@ -135,7 +136,7 @@ export namespace GanacheService {
 
     const {output, pid, port, process} = ganacheProcess;
     delete ganacheProcesses[port];
-    Output.dispose(OutputLabel.ganacheCommands, port.toString());
+    await Output.dispose(OutputLabel.ganacheCommands, port.toString());
 
     if (process) {
       removeAllListeners(process);

--- a/src/views/LogView.ts
+++ b/src/views/LogView.ts
@@ -75,6 +75,9 @@ export class LogView implements WebviewViewProvider {
    * @param description - represents the log description
    */
   public async createLog(label: OutputLabel, message: string, description?: string): Promise<void> {
+    // Displays the log panel. Unfortunately it doesn't load immediately so we have to wait for the html to load
+    // this._view?.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
+
     // Checks if the log panel has already been loaded and is visible
     if (this._view == null || this._view?.visible === false) {
       // If it has not yet been loaded, save the log to be executed after loading the log panel
@@ -96,7 +99,7 @@ export class LogView implements WebviewViewProvider {
    */
   public async disposeTab(label: OutputLabel, description?: string): Promise<void> {
     // Displays the log panel. Unfortunately it doesn't load immediately so we have to wait for the html to load
-    this._view?.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
+    // this._view?.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
 
     // Checks if the log panel has already been loaded and is visible
     if (this._view?.visible === false) {

--- a/test/commands/GanacheService.test.ts
+++ b/test/commands/GanacheService.test.ts
@@ -71,7 +71,7 @@ describe('Unit tests GanacheService', () => {
     });
   });
 
-  ['1', '65535', '8454', 8000, 8454].forEach((port) => {
+  ['1', '65535', 8000, 8454].forEach((port) => {
     it(`startGanacheServer should pass validation if port is ${port}`, async () => {
       // Arrange
       const urlValidatorSpy = sinon.spy(UrlValidator, 'validatePort');

--- a/test/commands/ProjectCommand.test.ts
+++ b/test/commands/ProjectCommand.test.ts
@@ -709,8 +709,8 @@ describe('ProjectCommands', () => {
 
     it('Method getTruffleUnboxCommand should return a value', async () => {
       // Arrange
-      const displayName = 'drizzle';
-      const repoName = 'drizzle-box';
+      const displayName = 'pet-shop';
+      const repoName = 'pet-shop-box';
       const projectCommandsRewire = rewire('../../src/commands/ProjectCommands');
       const getTruffleUnboxCommand = projectCommandsRewire.__get__('getTruffleUnboxCommand');
       const showQuickPickMock = sinon.stub(vscode.window, 'showQuickPick');


### PR DESCRIPTION
## PR description

ref: #234

As requested, I've rolled back the log while retaining the **Truffle Panel Log** in passive mod and utilising output channels. To preserve the genuine user experience, all regulations were reinstated and upheld. To make it simple to remove (or keep) the old log code in the future, I've marked it with the following text: `// INFO: THIS IS THE OLD VERSION OF LOGGER USING OUTPUT CHANNELS`

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
