### PR TITLE
Spurious closing bracket on "Create sample project" entry when creating a new project

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -505,7 +505,7 @@ export class Constants {
     },
     description: {
       emptyProject: 'Empty project equivalent of truffle init',
-      sampleProject: 'Sample project (current vscode-starter-box) with some enhancements)',
+      sampleProject: 'Sample project (current vscode-starter-box with some enhancements)',
       projectFromTruffleBox:
         'Project from Truffle Box (which will launch another dropdown with the full list of all boxes)',
     },


### PR DESCRIPTION
## PR description

ref: #235

Spurious closing bracket on "Create sample project" has been fixed

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
