### PR TITLE
fix: minor stylistic tweaks to output tabs

### DIFF
--- a/resources/logPanel/main.css
+++ b/resources/logPanel/main.css
@@ -16,7 +16,6 @@ div.tab-frame label {
   cursor: pointer;
   min-height: 15px;
   margin-right: 2px;
-  color: #f2ede7;
   text-transform: uppercase;
   font-size: 12px;
 }
@@ -38,7 +37,6 @@ div.tab-frame div.tab {
   padding: 10px;
   clear: left;
   height: 85vh;
-  color: #fff;
   overflow-y: scroll;
 }
 

--- a/resources/logPanel/main.css
+++ b/resources/logPanel/main.css
@@ -19,7 +19,6 @@ div.tab-frame label {
   color: #f2ede7;
   text-transform: uppercase;
   font-size: 12px;
-  background-color: #33262a;
 }
 
 div.tab-frame label img {
@@ -30,9 +29,8 @@ div.tab-frame label img {
 }
 
 div.tab-frame input:checked + label {
-  background: #40e0c5;
-  color: #33262a;
-  cursor: default;
+  border-bottom: solid 1px #40e0c5;
+  cursor: hover;
 }
 
 div.tab-frame div.tab {


### PR DESCRIPTION
## PR description

Adjusts the visual styling on the output channel tabs so it's more inline with that of VS Code's aesthetic (example below). 

<img width="607" alt="Screen Shot 2022-10-07 at 3 30 26 PM" src="https://user-images.githubusercontent.com/210755/194649845-dcd24fce-abd0-4142-92e3-3aefc8610d73.png">

Also including accommodations for light(er) modes which were not displaying correctly:

<img width="512" alt="Screen Shot 2022-10-07 at 3 53 20 PM" src="https://user-images.githubusercontent.com/210755/194651191-8a4d9aba-7219-4757-b346-c4afc30d44d8.png">

With resolution:
 
<img width="522" alt="Screen Shot 2022-10-07 at 3 53 51 PM" src="https://user-images.githubusercontent.com/210755/194651203-bd415687-c443-43f9-b823-5c2aeb15c669.png">

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
