### PR TITLE
Fix: Webpack options

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -26,10 +26,10 @@ module.exports = {
     callback();
   },
   resolve: {
-    // .json is added to prevent import error from /node_modules/got/index.js
     alias: {
       'original-require': require.resolve('./polyfills/original-require'),
     },
+    // .json is added to prevent import error from /node_modules/got/index.js
     extensions: ['.ts', '.js', '.json'],
     plugins: [
       new TsconfigPathsPlugin({

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,7 +3,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
-  devtool: 'source-map',
+  devtool: 'eval',
   optimization: {
     minimize: true,
   },


### PR DESCRIPTION
## PR description

The`devtool` option was changed from `source-map` to `eval`. We know that this may not be the best option, however, the memory of the virtual machines was overflowing due to the large use of resources to generate the code mapping.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
