### PR TITLE
Feature/246 remove deprecated networks

### DIFF
--- a/resources/welcome/main.css
+++ b/resources/welcome/main.css
@@ -1,3 +1,6 @@
+/* Copyright (c) 2022. Consensys Software Inc. All rights reserved. */
+/* Licensed under the MIT license. */
+
 * {
   box-sizing: border-box;
   font-family: 'Segoe UI', sans-serif;
@@ -303,15 +306,20 @@ footer {
   max-height: 60px;
 }
 
-.required-app div {
+.required-app div,
+.required-app span {
   margin: 10px 0;
-  font-size: 15px;
+  font-size: 13px;
   text-align: center;
-  line-height: 20px;
+  line-height: 16px;
 }
 
 .required-app .version {
   color: mediumaquamarine;
+}
+
+.required-app .versionInvalid {
+  color: hotpink;
 }
 
 .required-app a {
@@ -339,6 +347,7 @@ footer {
 .required-app a.spinner span {
   visibility: hidden;
 }
+
 /*#endregion required*/
 
 /*#region spinner*/
@@ -364,6 +373,7 @@ footer {
   border-bottom-color: #ffffff;
   animation: spinner 0.8s ease infinite;
 }
+
 /*#endregion spinner*/
 
 /*#region partners*/
@@ -404,6 +414,7 @@ footer {
 .specific-partner > img {
   flex: 1;
 }
+
 /*#endregion partners*/
 
 /*#region sidebar*/

--- a/resources/welcome/prereqs.html
+++ b/resources/welcome/prereqs.html
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2022. Consensys Software Inc. All rights reserved. -->
+<!-- Licensed under the MIT license. -->
+
 <!DOCTYPE html>
 <html>
   <head>
@@ -33,8 +36,11 @@
               <div id="node" class="required-app disabled">
                 <img src="{{root}}/images/NodeLogo.png" />
                 <div class="description">
-                  Required version:
-                  <span class="version">⌃14.0.0 and ⌵17.0.0</span>
+                  Required:
+                  <span class="version">{{node}}</span>
+                  <br />
+                  Installed:
+                  <span class="{{node-version}}">{{node-installed}}</span>
                 </div>
                 <a class="spinner" href="https://nodejs.org">
                   <span>Install Node.js</span>
@@ -43,8 +49,11 @@
               <div id="git" class="required-app disabled">
                 <img src="{{root}}/images/GitLogo.png" />
                 <div class="description">
-                  Required version:
-                  <span class="version">2.10.0</span>
+                  Required:
+                  <span class="version">{{git}}</span>
+                  <br />
+                  Installed:
+                  <span class="{{git-version}}">{{git-installed}}</span>
                 </div>
                 <a class="spinner" href="https://git-scm.com/downloads">
                   <span>Install Git</span>
@@ -53,8 +62,11 @@
               <div id="npm" class="required-app disabled">
                 <img src="{{root}}/images/NpmLogo.png" />
                 <div class="description">
-                  Required version:
-                  <span class="version">⌃6.14.15 and ⌵9.0.0</span>
+                  Required:
+                  <span class="version">{{npm}}</span>
+                  <br />
+                  Installed:
+                  <span class="{{npm-version}}">{{npm-installed}}</span>
                 </div>
                 <a id="installNpm" class="spinner action" title="Install NPM">
                   <span>Install NPM</span>
@@ -71,8 +83,11 @@
               <div id="truffle" class="required-app disabled">
                 <img src="{{root}}/images/TruffleLogo.svg" />
                 <div class="description">
-                  Required version:
-                  <span class="version">⌃5.0.0 and ⌵6.0.0</span>
+                  Required:
+                  <span class="version">{{truffle}}</span>
+                  <br />
+                  Installed:
+                  <span class="{{truffle-version}}">{{truffle-installed}}</span>
                 </div>
                 <a
                   id="installTruffle"
@@ -85,8 +100,11 @@
               <div id="ganache" class="required-app disabled">
                 <img src="{{root}}/images/GanacheLogo.png" />
                 <div class="description">
-                  Required version:
-                  <span class="version">⌃6.0.0 and ⌵8.0.0</span>
+                  Required:
+                  <span class="version">{{ganache}}</span>
+                  <br />
+                  Installed:
+                  <span class="{{ganache-version}}">{{ganache-installed}}</span>
                 </div>
                 <a
                   id="installGanache"

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -97,7 +97,7 @@ export class Constants {
   public static requiredVersions: {[key: string]: string | {min: string; max: string}} = {
     [RequiredApps.ganache]: {
       max: '8.0.0',
-      min: '6.0.0',
+      min: '7.4.3', // min post merge version with sepolia support.
     },
     [RequiredApps.git]: '2.10.0',
     [RequiredApps.hdwalletProvider]: {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Consensys Software Inc. All rights reserved.
+// Copyright (c) 2022. Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
 import os from 'os';
@@ -323,10 +323,8 @@ export class Constants {
             isForked: true,
             networks: {
               mainnet: 'Mainnet',
-              ropsten: 'Ropsten',
-              kovan: 'Kovan',
-              rinkeby: 'Rinkeby',
               goerli: 'Goerli',
+              sepolia: 'Sepolia',
               other: 'Other...',
             },
           },
@@ -462,18 +460,14 @@ export class Constants {
   // More information see here
   // https://ethereum.stackexchange.com/questions/17051/how-to-select-a-network-id-or-is-there-a-list-of-network-ids
   public static infuraEndpointsIds: {[key: string]: number} = {
-    goerli: 5,
-    kovan: 42,
     mainnet: 1,
-    rinkeby: 4,
-    ropsten: 3,
+    goerli: 5,
+    sepolia: 11155111,
     'arbitrum-mainnet': 42161,
-    'arbitrum-rinkeby': 421611,
     'aurora-mainnet': 1313161554,
     'aurora-testnet': 1313161555,
     'near-mainnet': 0,
     'near-testnet': 0,
-    'optimism-kovan': 69,
     'optimism-mainnet': 10,
     'polygon-mainnet': 137,
     'polygon-mumbai': 80001,
@@ -829,10 +823,8 @@ export class Constants {
 
 export enum ChainId {
   ETHEREUM = 1,
-  ROPSTEN = 3,
-  RINKEBY = 4,
-  GÖRLI = 5,
-  KOVAN = 42,
+  GOERLI = 5,
+  SEPOLIA = 11155111,
   MATIC = 137,
   MATIC_TESTNET = 80001,
   FANTOM = 250,

--- a/src/commands/ServiceCommands.ts
+++ b/src/commands/ServiceCommands.ts
@@ -1,12 +1,12 @@
-// Copyright (c) Consensys Software Inc. All rights reserved.
+// Copyright (c) 2022. Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
-import {QuickPickItem} from 'vscode';
-import {Constants} from '../Constants';
-import {telemetryHelper} from '../helpers';
-import {showInputBox, showQuickPick} from '../helpers/userInteraction';
-import {ItemType} from '../Models';
+import {Constants} from '@/Constants';
+import {showInputBox, showQuickPick} from '@/helpers/userInteraction';
+import {ItemType} from '@/Models';
 import {
+  GenericProject,
+  GenericService,
   InfuraProject,
   InfuraService,
   LocalProject,
@@ -15,13 +15,13 @@ import {
   Service,
   ServiceTypes,
   TLocalProjectOptions,
-  GenericProject,
-  GenericService,
-} from '../Models/TreeItems';
-import {InfuraResourceExplorer, LocalResourceExplorer, GenericResourceExplorer} from '../resourceExplorers';
-import {GanacheService, TreeManager} from '../services';
-import {Telemetry} from '../TelemetryClient';
-import {ProjectView} from '../ViewItems';
+} from '@/Models/TreeItems';
+import {GenericResourceExplorer, InfuraResourceExplorer, LocalResourceExplorer} from '@/resourceExplorers';
+import {GanacheService, TreeManager} from '@/services';
+import {Telemetry} from '@/TelemetryClient';
+import {ProjectView} from '@/ViewItems';
+import {QuickPickItem} from 'vscode';
+import {telemetryHelper} from '../helpers';
 
 interface IServiceDestination {
   cmd: (service: Service) => Promise<Project>;
@@ -258,7 +258,7 @@ async function getBlockNumber(): Promise<number> {
 }
 
 async function getHostAddress(): Promise<string> {
-  const url: string = await showInputBox({
+  return await showInputBox({
     ignoreFocusOut: true,
     prompt: Constants.paletteLabels.enterNetworkUrl,
     placeHolder: Constants.placeholders.enterNetworkUrl,
@@ -269,12 +269,10 @@ async function getHostAddress(): Promise<string> {
       return null;
     },
   });
-
-  return url;
 }
 
 async function loadServiceType(): Promise<TServiceType[]> {
-  const networks: TServiceType[] = [
+  return [
     {
       label: Constants.treeItemData.service.local.type.default.label,
       isForked: Constants.treeItemData.service.local.type.default.isForked,
@@ -287,16 +285,12 @@ async function loadServiceType(): Promise<TServiceType[]> {
       description: Constants.treeItemData.service.local.type.forked.description,
       networks: [
         {label: Constants.treeItemData.service.local.type.forked.networks.mainnet},
-        {label: Constants.treeItemData.service.local.type.forked.networks.ropsten},
-        {label: Constants.treeItemData.service.local.type.forked.networks.kovan},
-        {label: Constants.treeItemData.service.local.type.forked.networks.rinkeby},
         {label: Constants.treeItemData.service.local.type.forked.networks.goerli},
+        {label: Constants.treeItemData.service.local.type.forked.networks.sepolia},
         {label: Constants.treeItemData.service.local.type.forked.networks.other},
       ],
     },
   ];
-
-  return networks;
 }
 
 async function addChild(service: Service, child: Project): Promise<void> {

--- a/src/functions/explorer.ts
+++ b/src/functions/explorer.ts
@@ -1,4 +1,7 @@
-import {ChainId} from '../Constants';
+// Copyright (c) 2022. Consensys Software Inc. All rights reserved.
+// Licensed under the MIT license.
+
+import {ChainId} from '@/Constants';
 
 const explorers = {
   etherscan: (link: string, data: string, type: 'transaction' | 'token' | 'address' | 'block') => {
@@ -33,24 +36,14 @@ const chains: Chains = {
     link: 'https://etherscan.io',
     builder: explorers.etherscan,
   },
-  [ChainId.ROPSTEN]: {
-    name: 'Ropsten',
-    link: 'https://ropsten.etherscan.io',
-    builder: explorers.etherscan,
-  },
-  [ChainId.RINKEBY]: {
-    name: 'Rinkeby',
-    link: 'https://rinkeby.etherscan.io',
-    builder: explorers.etherscan,
-  },
-  [ChainId.GÖRLI]: {
+  [ChainId.GOERLI]: {
     name: 'Goerli',
     link: 'https://goerli.etherscan.io',
     builder: explorers.etherscan,
   },
-  [ChainId.KOVAN]: {
-    name: 'Kovan',
-    link: 'https://kovan.etherscan.io',
+  [ChainId.SEPOLIA]: {
+    name: 'Sepolia',
+    link: 'https://sepolia.etherscan.io',
     builder: explorers.etherscan,
   },
   [ChainId.MATIC]: {
@@ -73,11 +66,11 @@ const chains: Chains = {
     link: 'https://testnet.ftmscan.com',
     builder: explorers.etherscan,
   },
-  [ChainId.KILN]: {
-    name: 'Kiln',
-    link: 'https://explorer.kiln.themerge.dev/',
-    builder: explorers.etherscan,
-  },
+  //   [ChainId.KILN]: {
+  //     name: 'Kiln',
+  //     link: 'https://explorer.kiln.themerge.dev/',
+  //     builder: explorers.etherscan,
+  //   },
   //   [ChainId.BSC]: {
   //     link: 'https://bscscan.com',
   //     builder: explorers.etherscan,

--- a/src/resourceExplorers/GenericResourceExplorer.ts
+++ b/src/resourceExplorers/GenericResourceExplorer.ts
@@ -1,13 +1,13 @@
-// Copyright (c) Consensys Software Inc. All rights reserved.
+// Copyright (c) 2022. Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
-import {Constants} from '../Constants';
-import {showInputBox} from '../helpers/userInteraction';
-import {GenericNetworkNode, GenericProject} from '../Models/TreeItems';
-import {GenericService} from '../services';
-import {Telemetry} from '../TelemetryClient';
-import {DialogResultValidator} from '../validators/DialogResultValidator';
-import {UrlValidator} from '../validators/UrlValidator';
+import {Constants} from '@/Constants';
+import {showInputBox} from '@/helpers/userInteraction';
+import {GenericNetworkNode, GenericProject} from '@/Models/TreeItems';
+import {GenericService} from '@/services';
+import {Telemetry} from '@/TelemetryClient';
+import {DialogResultValidator} from '@/validators/DialogResultValidator';
+import {UrlValidator} from '@/validators/UrlValidator';
 
 export class GenericResourceExplorer {
   public async selectProject(existingProjects: string[] = [], existingPorts: number[] = []): Promise<GenericProject> {

--- a/src/resourceExplorers/InfuraResourceExplorer.ts
+++ b/src/resourceExplorers/InfuraResourceExplorer.ts
@@ -1,15 +1,15 @@
-// Copyright (c) Consensys Software Inc. All rights reserved.
+// Copyright (c) 2022. Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
 import {QuickPickItem, window} from 'vscode';
-import {Constants} from '../Constants';
-import {showInputBox, showQuickPick} from '../helpers/userInteraction';
-import {InfuraProjectItem} from '../Models/QuickPickItems';
-import {InfuraNetworkNode, InfuraProject} from '../Models/TreeItems';
-import {InfuraLayer} from '../Models/TreeItems/InfuraLayer';
-import {IInfuraEndpointDto, IInfuraProjectDto, IInfuraProjectQuickPick} from '../services/infuraService/InfuraDto';
-import {InfuraServiceClient} from '../services/infuraService/InfuraServiceClient';
-import {Telemetry} from '../TelemetryClient';
+import {Constants} from '@/Constants';
+import {showInputBox, showQuickPick} from '@/helpers/userInteraction';
+import {InfuraProjectItem} from '@/Models/QuickPickItems';
+import {InfuraNetworkNode, InfuraProject} from '@/Models/TreeItems';
+import {InfuraLayer} from '@/Models/TreeItems';
+import {IInfuraEndpointDto, IInfuraProjectDto, IInfuraProjectQuickPick} from '@/services/infuraService/InfuraDto';
+import {InfuraServiceClient} from '@/services';
+import {Telemetry} from '@/TelemetryClient';
 
 export class InfuraResourceExplorer {
   public async createProject(existingProjects: string[] = []): Promise<InfuraProject> {
@@ -124,7 +124,7 @@ export class InfuraResourceExplorer {
       }
     );
 
-    return answer.label === Constants.projectAvailability.private ? true : false;
+    return answer.label === Constants.projectAvailability.private;
   }
 
   private async getInfuraProject(

--- a/src/resourceExplorers/LocalResourceExplorer.ts
+++ b/src/resourceExplorers/LocalResourceExplorer.ts
@@ -1,13 +1,13 @@
-// Copyright (c) Consensys Software Inc. All rights reserved.
+// Copyright (c) 2022. Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
-import {Constants} from '../Constants';
-import {showInputBox} from '../helpers/userInteraction';
-import {LocalNetworkNode, LocalProject, TLocalProjectOptions} from '../Models/TreeItems';
-import {GanacheService} from '../services';
-import {Telemetry} from '../TelemetryClient';
-import {DialogResultValidator} from '../validators/DialogResultValidator';
-import {UrlValidator} from '../validators/UrlValidator';
+import {Constants} from '@/Constants';
+import {showInputBox} from '@/helpers/userInteraction';
+import {LocalNetworkNode, LocalProject, TLocalProjectOptions} from '@/Models/TreeItems';
+import {GanacheService} from '@/services';
+import {Telemetry} from '@/TelemetryClient';
+import {DialogResultValidator} from '@/validators/DialogResultValidator';
+import {UrlValidator} from '@/validators/UrlValidator';
 
 export class LocalResourceExplorer {
   public async createProject(

--- a/test/commands/GanacheService.test.ts
+++ b/test/commands/GanacheService.test.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Consensys Software Inc. All rights reserved.
+// Copyright (c) 2022. Consensys Software Inc. All rights reserved.
 // Licensed under the MIT license.
 
 import assert from 'assert';
@@ -120,7 +120,7 @@ describe('Unit tests GanacheService', () => {
     const spawnStub = sinon.stub(outputCommandHelper, 'spawnProcess').returns(processMock as cp.ChildProcess);
     const options: TLocalProjectOptions = {
       isForked: true,
-      forkedNetwork: 'rinkeby',
+      forkedNetwork: 'goerli',
       blockNumber: 1000,
       url: '',
     };


### PR DESCRIPTION
## PR description

Fixing the deprecated networks list.

- Added in sepolia support
- Fixed requirements page to show actual values of supported and installed versions to make it easier for users to understand what the mismatch, if any, is.
- CSS changes on requirements page
- Tested against Ganache 7.4.3 as now min supported version.


## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

We may need to note that we now have a hard min limit of Ganache support post merge to 7.4.3 as this was the first version to support Sepolia as a forked network.
