### PR TITLE
Contracts not detected

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,13 @@
   ],
   "javascript.referencesCodeLens.enabled": true,
   "typescript.implementationsCodeLens.enabled": true,
-  "typescript.referencesCodeLens.enabled": true
+  "typescript.referencesCodeLens.enabled": true,
+  "chronicler.ffmpeg-binary": "/Users/xhulz/Documents/ffmpeg",
+  "chronicler.dest-folder": "/Users/xhulz/Documents/Recordings",
+  "chronicler.recording-defaults": {
+    "animatedGif": true,
+    "flags": null,
+    "fps": 10,
+    "countdown": 3
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,13 +21,5 @@
   ],
   "javascript.referencesCodeLens.enabled": true,
   "typescript.implementationsCodeLens.enabled": true,
-  "typescript.referencesCodeLens.enabled": true,
-  "chronicler.ffmpeg-binary": "/Users/xhulz/Documents/ffmpeg",
-  "chronicler.dest-folder": "/Users/xhulz/Documents/Recordings",
-  "chronicler.recording-defaults": {
-    "animatedGif": true,
-    "flags": null,
-    "fps": 10,
-    "countdown": 3
-  }
+  "typescript.referencesCodeLens.enabled": true
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -606,6 +606,7 @@ export class Constants {
     WorkspaceShouldBeOpened: 'Workspace should be opened',
     DashboardVersionError: 'Please upgrade to the latest version of Truffle to use this feature',
     FetchingBoxesHasFailed: 'An error occurred while fetching boxes',
+    ContractFolderNotExists: 'No contract folder found for this workspace. Please create a contract folder.',
   };
 
   public static informationMessage = {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -600,12 +600,12 @@ export class Constants {
     SubscriptionNotFound: 'Can not find available subscription.',
     ThereAreNoMnemonics: 'There are no mnemonics',
     TruffleConfigHasIncorrectFormat: '"truffle-config.js" has incorrect format',
-    TruffleConfigIsNotExist: 'Truffle configuration file not found',
+    TruffleConfigIsNotExist: 'Unable to locate the truffle configuration file',
     VariableShouldBeDefined: Constants.getMessageVariableShouldBeDefined,
     WorkspaceShouldBeOpened: 'Workspace should be opened',
     DashboardVersionError: 'Please upgrade to the latest version of Truffle to use this feature',
     FetchingBoxesHasFailed: 'An error occurred while fetching boxes',
-    ContractFolderNotExists: 'There was no contract directory in this workspace.',
+    ContractFolderNotExists: 'There is no contract directory in this workspace',
   };
 
   public static informationMessage = {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -62,7 +62,6 @@ export class Constants {
   public static dashboardRetryAttempts = 5;
 
   public static fileExplorerConfig = {
-    contractFolder: 'contracts',
     contextValue: {
       root: 'root',
       folder: 'folder',
@@ -606,7 +605,7 @@ export class Constants {
     WorkspaceShouldBeOpened: 'Workspace should be opened',
     DashboardVersionError: 'Please upgrade to the latest version of Truffle to use this feature',
     FetchingBoxesHasFailed: 'An error occurred while fetching boxes',
-    ContractFolderNotExists: 'No contract folder found for this workspace. Please create a contract folder.',
+    ContractFolderNotExists: 'No contract folder found in this workspace. Please create a contract folder.',
   };
 
   public static informationMessage = {

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -605,7 +605,7 @@ export class Constants {
     WorkspaceShouldBeOpened: 'Workspace should be opened',
     DashboardVersionError: 'Please upgrade to the latest version of Truffle to use this feature',
     FetchingBoxesHasFailed: 'An error occurred while fetching boxes',
-    ContractFolderNotExists: 'No contract folder found in this workspace. Please create a contract folder.',
+    ContractFolderNotExists: 'There was no contract directory in this workspace.',
   };
 
   public static informationMessage = {

--- a/src/views/Utils.ts
+++ b/src/views/Utils.ts
@@ -1,8 +1,0 @@
-import vscode from 'vscode';
-
-/**
- * Gets the first Workspace folder or undefined.
- */
-export function getWorkspaceFolder(): vscode.WorkspaceFolder | undefined {
-  return vscode.workspace.workspaceFolders?.filter((folder) => folder.uri.scheme === 'file')[0];
-}


### PR DESCRIPTION
## PR description

Issue ref: #248

When more than one workspace is opened on Visual Studio Code, the Explorer View does not find the contract folder. This patch fixes this situation and displays the directory regardless of location

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
