### PR TITLE
Fetch external sources when debugging a forked network

### DIFF
--- a/package.json
+++ b/package.json
@@ -811,6 +811,7 @@
     "@truffle/config": "1.3.38",
     "@truffle/debug-utils": "^6.0.26",
     "@truffle/debugger": "^10.0.14",
+    "@truffle/fetch-and-compile": "^0.5.19",
     "@truffle/resolver": "^9.0.4",
     "@truffle/workflow-compile": "^4.0.36",
     "abi-decoder": "^2.4.0",

--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -35,7 +35,7 @@ export namespace DebuggerCommands {
       const txHashesAsQuickPickItems = await getQuickPickItems(transactionProvider);
 
       const moreTxs = {
-        label: '$(edit) Manually enter the transaction hash',
+        label: '$(edit) Manually enter the transaction hash (experimental)',
         detail: 'Note that if the target network is forked, an attempt will be made to fetch the source',
         alwaysShow: true,
       } as QuickPickItem;
@@ -47,6 +47,9 @@ export namespace DebuggerCommands {
           {
             ignoreFocusOut: true,
             placeHolder: 'Select the transaction hash to debug',
+            // TODO: It would be nice to filter by contract's name and/or method name
+            // matchOnDescription: true,
+            // matchOnDetail: true,
           }
         );
       else {

--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -37,7 +37,8 @@ export namespace DebuggerCommands {
       const txHashesAsQuickPickItems = await getQuickPickItems(transactionProvider);
 
       const moreTxs = {
-        label: 'Or enter a transaction manually',
+        label: '$(edit) Manually enter the transaction hash',
+        detail: 'Note that if the target network is forked, an attempt will be made to fetch the source',
         alwaysShow: true,
       } as QuickPickItem;
 

--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -46,7 +46,7 @@ export namespace DebuggerCommands {
           [...txHashesAsQuickPickItems, {kind: QuickPickItemKind.Separator, label: ''}, moreTxs],
           {
             ignoreFocusOut: true,
-            placeHolder: 'Enter the transaction hash to debug',
+            placeHolder: 'Select the transaction hash to debug',
           }
         );
       else {

--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -29,8 +29,6 @@ export namespace DebuggerCommands {
     const web3 = new Web3Wrapper(debugNetworkOptions);
     const providerUrl = web3.getProviderUrl();
 
-    // const workspaceFolder = workspace.getWorkspaceFolder(workspaceUri);
-
     if (debugNetwork.isLocalNetwork()) {
       // if local service then provide last transactions to choose
       const transactionProvider = new TransactionProvider(web3, contractBuildDir);
@@ -93,11 +91,7 @@ async function getQuickPickItems(txProvider: TransactionProvider) {
   });
 }
 
-export function generateDebugAdapterConfig(
-  txHash: string,
-  workingDirectory: string,
-  providerUrl: string
-): DebugConfiguration {
+function generateDebugAdapterConfig(txHash: string, workingDirectory: string, providerUrl: string): DebugConfiguration {
   return {
     files: [],
     name: 'Debug Transactions',
@@ -107,7 +101,7 @@ export function generateDebugAdapterConfig(
     type: DEBUG_TYPE,
     workingDirectory,
     timeout: 30000,
-  } as DebugConfiguration;
+  };
 }
 
 export async function startDebugging(txHash: string, workingDirectory: string, providerUrl: string): Promise<void> {

--- a/src/debugAdapter/debugNetwork.ts
+++ b/src/debugAdapter/debugNetwork.ts
@@ -97,7 +97,7 @@ export class DebugNetwork {
    *
    * @returns an Array of `LocalProject` from the _Networks_ view.
    */
-  public getProjects(): LocalProject[] {
+  private getProjects(): LocalProject[] {
     const services = TreeManager.getItem(ItemType.LOCAL_SERVICE);
 
     if (!services || !services.getChildren()) {

--- a/src/debugAdapter/debugNetwork.ts
+++ b/src/debugAdapter/debugNetwork.ts
@@ -97,7 +97,7 @@ export class DebugNetwork {
    *
    * @returns an Array of `LocalProject` from the _Networks_ view.
    */
-  private getProjects(): LocalProject[] {
+  public getProjects(): LocalProject[] {
     const services = TreeManager.getItem(ItemType.LOCAL_SERVICE);
 
     if (!services || !services.getChildren()) {

--- a/src/debugAdapter/debugNetwork.ts
+++ b/src/debugAdapter/debugNetwork.ts
@@ -69,11 +69,13 @@ export class DebugNetwork {
   private async loadNetworkForDebug(providerUrl?: string): Promise<INetwork> {
     const projects = this.getProjects();
     const host = await this.getHost(projects, providerUrl);
+    const projectOptions = (host.getParent() as LocalProject).options;
 
     const networkOptionsForDebug: INetworkOption = {
       host: host.url.hostname,
       network_id: host.networkId,
       port: host.port,
+      isForked: projectOptions.isForked,
     };
 
     const networkForDebug: INetwork = {

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -203,7 +203,6 @@ export default class RuntimeInterface extends EventEmitter {
     this.validateSession();
     const currentLocation = this._session!.view(this._selectors.controller.current.location);
     const sourcePath = this._session!.view(this._selectors.sourcemapping.current.source).sourcePath;
-
     if (!sourcePath) {
       throw new Error('No source file');
     }

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -209,13 +209,7 @@ export default class RuntimeInterface extends EventEmitter {
       throw new Error('No source file');
     }
     // so if we have a file in a location that doesn't map 1:1 to the actual file name in the compiler we map it here...
-    // const file = this._mappedSources.has(sourcePath) ? this._mappedSources.get(sourcePath) : sourcePath;
-    let file: string;
-    if (this._mappedSources.has(sourcePath)) {
-      file = this._mappedSources.get(sourcePath)!;
-    } else {
-      file = sourcePath;
-    }
+    const file = this._mappedSources.has(sourcePath) ? this._mappedSources.get(sourcePath) : sourcePath;
 
     return {
       column: currentLocation.sourceRange ? currentLocation.sourceRange.lines.start.column : 0,

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -185,7 +185,7 @@ export default class RuntimeInterface extends EventEmitter {
     for (const compilation of Object.values(byId) as {compilationId: string; source: string; sourcePath: string}[]) {
       if (compilation.compilationId.startsWith('externalFor')) {
         const tmp = os.tmpdir();
-        const sourcePath = tmp + '/' + compilation.sourcePath;
+        const sourcePath = path.join(tmp, compilation.sourcePath);
 
         const sourceDir = path.dirname(sourcePath);
         mkdirpSync(sourceDir);

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -160,11 +160,18 @@ export default class RuntimeInterface extends EventEmitter {
   }
 
   /**
+   * Serialize any (fetched) external sources into a temporary folder
+   * to be later opened by VS Code editor.
    *
+   * Whenever this `Session` has been initialized with fetch external sources,
+   * _i.e._, `fetchAndCompileForDebugger`,
+   * the corresponding sources are stores in this `Session`'s state.
+   * This method serialize these sources into a temporary folder.
    */
   private serializeExternalSources() {
     const byId = this._session!.view(this._selectors.sourcemapping.info.sources).byId;
 
+    // This guard is used so far in tests.
     if (byId === undefined) {
       return;
     }
@@ -180,9 +187,10 @@ export default class RuntimeInterface extends EventEmitter {
   }
 
   /**
+   * Retrieves the chain id of the `providerUrl`.
    *
-   * @param providerUrl
-   * @returns
+   * @param providerUrl the url to get chain id from.
+   * @returns the chain id of the given `providerUrl`.
    */
   private getNetworkId(providerUrl: string) {
     const services = TreeManager.getItem(ItemType.LOCAL_SERVICE);
@@ -245,6 +253,19 @@ export default class RuntimeInterface extends EventEmitter {
     }
   }
 
+  /**
+   * Generates the Truffle Debugger `Session`.
+   *
+   * `networkId` indicates which network this `Session`'s provider is forking from, if any.
+   * When `networkId` is defined,
+   * the Truffle `fetch-and-compile` module is used to fetch external sources,
+   * currently from Etherscan.
+   *
+   * @param txHash
+   * @param networkId
+   * @param options
+   * @returns
+   */
   private async generateSession(
     txHash: string,
     networkId: string | number | undefined,

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -170,9 +170,9 @@ export default class RuntimeInterface extends EventEmitter {
    * This method serialize these Session's sources into a temporary folder
    * (as returned by `os.tmpdir()`).
    *
-   * > Moreover, if the source path of contract being serialized is a nested path,
+   * > Moreover, if the source path of a contract being serialized is a nested path,
    * > _.e.g._, `/@openzeppelin/contracts/access/Ownable.sol`,
-   * this method creates the whole folder path.
+   * this method creates the full folder path.
    */
   private serializeExternalSources() {
     const byId = this._session!.view(this._selectors.sourcemapping.info.sources).byId;

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -202,8 +202,7 @@ export default class RuntimeInterface extends EventEmitter {
   public currentLine(): DebuggerTypes.IFrame {
     this.validateSession();
     const currentLocation = this._session!.view(this._selectors.controller.current.location);
-    const source = this._session!.view(this._selectors.sourcemapping.current.source);
-    const sourcePath = source.sourcePath;
+    const sourcePath = this._session!.view(this._selectors.sourcemapping.current.source).sourcePath;
 
     if (!sourcePath) {
       throw new Error('No source file');

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -213,8 +213,9 @@ export default class RuntimeInterface extends EventEmitter {
     const project = projects.find((project) => {
       const network = project.getChildren().at(0) as LocalNetworkNode;
       return `${network.url.protocol}//${network.url.host}` === providerUrl;
-    })!;
-    return getChainId(project.options.forkedNetwork);
+    });
+
+    return project ? getChainId(project.options.forkedNetwork) : undefined;
   }
 
   public currentLine(): DebuggerTypes.IFrame {

--- a/src/debugAdapter/types/@truffle/debugger.d.ts
+++ b/src/debugAdapter/types/@truffle/debugger.d.ts
@@ -37,6 +37,7 @@ declare module '@truffle/debugger' {
   type DebuggerOptions = {
     provider: Web3Provider;
     compilations?: Array<any>;
+    lightMode: boolean;
   };
 
   /**

--- a/src/functions/explorer.ts
+++ b/src/functions/explorer.ts
@@ -121,3 +121,7 @@ export const getChain = (chainId: number | undefined): ChainObject => {
   if (!chainId) return UnknownChain;
   return chains[chainId] ? chains[chainId] : UnknownChain;
 };
+
+export function getChainId(networkName: string): string | undefined {
+  return Object.entries(chains).find((chain) => chain[1].name === networkName)?.[0];
+}

--- a/src/helpers/ConfigurationReader.ts
+++ b/src/helpers/ConfigurationReader.ts
@@ -16,6 +16,12 @@ export interface INetworkOption {
   network_id: string | number;
   port?: number;
   host?: string;
+
+  /**
+   *
+   */
+  isForked?: boolean;
+
   /**
    * You will need this enabled to use the confirmations listener
    * or to hear Events using .on or .once. Default is false.

--- a/test/commands/DebuggerCommands.test.ts
+++ b/test/commands/DebuggerCommands.test.ts
@@ -54,8 +54,23 @@ describe('DebuggerCommands unit tests', () => {
     sinon.restore();
   });
 
-  it('should generate and show quickPick when debugNetwork.isLocalNetwork() is true', async () => {
+  it('should `showinputBox` when debugNetwork.isLocalNetwork() is true', async () => {
     // Arrange
+    sinon.stub(DebugNetwork.prototype, 'isLocalNetwork').returns(true);
+    const showInputBoxFn = sinon.stub(userInteraction, 'showInputBox').resolves('');
+
+    // Act
+    await debugCommands.DebuggerCommands.startSolidityDebugger();
+
+    // Assert
+    assert.strictEqual(mockGetTxHashes.calledOnce, true, 'getLastTransactionHashes should be called');
+    assert.strictEqual(mockGetTxInfos.calledOnce, true, 'getTransactionsInfo should be called');
+    assert.strictEqual(showInputBoxFn.called, true, 'showInputBox should be called');
+  });
+
+  it('should `showQuickPick` when debugNetwork.isLocalNetwork() is true', async () => {
+    // Arrange
+    mockGetTxInfos.resolves([{hash: '0x1234', contractName: 'MetaCoin', methodName: 'constructor()'}]);
     sinon.stub(DebugNetwork.prototype, 'isLocalNetwork').returns(true);
     const createQuickPickFn = sinon.stub(userInteraction, 'showQuickPick').resolves({} as QuickPickItem);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,7 +1122,7 @@
     "@truffle/error" "^0.1.1"
     colors "1.4.0"
 
-"@truffle/compile-solidity@^6.0.31":
+"@truffle/compile-solidity@^6.0.31", "@truffle/compile-solidity@^6.0.44":
   version "6.0.44"
   resolved "https://registry.yarnpkg.com/@truffle/compile-solidity/-/compile-solidity-6.0.44.tgz#e66a1a787c3a840ed9a25f368157a345a4cb9d22"
   integrity sha512-4ZGshtdRhJUGCxb2E0DLx3+3PQ+HJzjNPWZgFqCqMwl5xxtNqsrZtAoJcsWOFrfhq7HVE8aLv3De0PbOQOHdbQ==
@@ -1511,6 +1511,19 @@
     glob "^7.1.6"
     web3-utils "1.7.4"
 
+"@truffle/fetch-and-compile@^0.5.19":
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/@truffle/fetch-and-compile/-/fetch-and-compile-0.5.19.tgz#36364fa416e5d9d4a49f349cf189ea2aa3c56618"
+  integrity sha512-WZrxG6POZ8b2sS4vKjGWoxWHQkRC5EYSmZdCa8nnNbt31z/Us12Ie+nKlxBKFjSbtD/t8zVb3OfcFpLly/Xwpg==
+  dependencies:
+    "@truffle/codec" "^0.14.5"
+    "@truffle/compile-solidity" "^6.0.44"
+    "@truffle/config" "^1.3.38"
+    "@truffle/source-fetcher" "^1.0.17"
+    debug "^4.3.2"
+    semver "7.3.7"
+    web3-utils "1.7.4"
+
 "@truffle/interface-adapter@^0.5.21":
   version "0.5.21"
   resolved "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.21.tgz"
@@ -1653,6 +1666,17 @@
     fs-extra "^9.1.0"
     get-installed-path "^4.0.8"
     glob "^7.1.6"
+    web3-utils "1.7.4"
+
+"@truffle/source-fetcher@^1.0.17":
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/@truffle/source-fetcher/-/source-fetcher-1.0.17.tgz#068c29f32ba9051422951c14b844cc59fdc249f7"
+  integrity sha512-QZYjnhIqvcTEwRO1rIwiCMYLjYHcNwt0/ElLbsZGWUnpX0MMP2Nxlnvjmd4xStmenLcF8HUQexC8OCSfsy0fSg==
+  dependencies:
+    async-retry "^1.3.1"
+    axios "0.27.2"
+    debug "^4.3.1"
+    node-abort-controller "^3.0.1"
     web3-utils "1.7.4"
 
 "@truffle/source-map-utils@^1.3.88", "@truffle/source-map-utils@^1.3.96":
@@ -2928,7 +2952,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async-retry@^1.2.1:
+async-retry@^1.2.1, async-retry@^1.3.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
   integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==


### PR DESCRIPTION
## PR description

This PR closes #149. It uses the Truffle `fetch-and-compile` module to fetch external sources when debugging a forked network.

Currently it serializes the external sources in a temporary folder.
Whenever the path of a contract being serialized is a nested path, _.e.g._, `/@openzeppelin/contracts/access/Ownable.sol`,
the contract is serialized using its full path.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
