### PR TITLE
Running truffle debug with appropriate flag (--vscode) - Enhancements & Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "onCommand:truffle-vscode.views.dashboard.restartDashboardServer",
     "onCommand:truffle-vscode.views.dashboard.openDashboard",
     "onCommand:truffle-vscode.views.dashboard.copyRPCEndpointAddress",
-    "onDebug"
+    "onDebug",
+    "onUri"
   ],
   "contributes": {
     "configuration": {

--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -39,7 +39,10 @@ export namespace DebuggerCommands {
 
     const txHash = txHashSelection.detail || txHashSelection.label;
 
-    await startDebugging(txHash, workingDirectory, providerUrl);
+    // TODO: Add a way to select if the user wants to fetch external contracts
+    const fetchExternal = false;
+
+    await startDebugging(txHash, workingDirectory, providerUrl, fetchExternal);
   }
 }
 
@@ -55,7 +58,20 @@ async function getQuickPickItems(txProvider: TransactionProvider) {
   });
 }
 
-function generateDebugAdapterConfig(txHash: string, workingDirectory: string, providerUrl: string): DebugConfiguration {
+/**
+ * This function is reponsible to generate the debug configuration adapter with the given parameters.
+ *
+ * @param txHash A transaction hash.
+ * @param workingDirectory The working directory of the project.
+ * @param providerUrl The network provider url.
+ * @param fetchExternal Indicates if the debugger should fetch external contracts.
+ */
+function generateDebugAdapterConfig(
+  txHash: string,
+  workingDirectory: string,
+  providerUrl: string,
+  fetchExternal: boolean
+): DebugConfiguration {
   return {
     files: [],
     name: 'Debug Transactions',
@@ -65,12 +81,26 @@ function generateDebugAdapterConfig(txHash: string, workingDirectory: string, pr
     type: DEBUG_TYPE,
     workingDirectory,
     timeout: 30000,
+    fetchExternal,
   } as DebugConfiguration;
 }
 
-export async function startDebugging(txHash: string, workingDirectory: string, providerUrl: string): Promise<void> {
+/**
+ * This functions is responsible for starting the solidity debugger with the given parameters.
+ *
+ * @param txHash A transaction hash.
+ * @param workingDirectory The working directory of the project.
+ * @param providerUrl The network provider url.
+ * @param fetchExternal Indicates if the debugger should fetch external contracts.
+ */
+export async function startDebugging(
+  txHash: string,
+  workingDirectory: string,
+  providerUrl: string,
+  fetchExternal: boolean
+): Promise<void> {
   const workspaceFolder = workspace.getWorkspaceFolder(Uri.parse(workingDirectory));
-  const config = generateDebugAdapterConfig(txHash, workingDirectory, providerUrl);
+  const config = generateDebugAdapterConfig(txHash, workingDirectory, providerUrl, fetchExternal);
 
   debug.startDebugging(workspaceFolder, config).then(() => {
     Telemetry.sendEvent('DebuggerCommands.startSolidityDebugger.commandFinished');

--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -39,7 +39,7 @@ export namespace DebuggerCommands {
 
     const txHash = txHashSelection.detail || txHashSelection.label;
 
-    // TODO: Add a way to select if the user wants to fetch external contracts
+    // TODO: Add a way to select if the user wants to fetch external contracts. For now, we will keep it as false.
     const fetchExternal = false;
 
     await startDebugging(txHash, workingDirectory, providerUrl, fetchExternal);

--- a/src/commands/DebuggerCommands.ts
+++ b/src/commands/DebuggerCommands.ts
@@ -10,7 +10,7 @@ import {shortenHash} from '@/debugAdapter/functions';
 import {TransactionProvider} from '@/debugAdapter/transaction/transactionProvider';
 import {Web3Wrapper} from '@/debugAdapter/web3Wrapper';
 import {getTruffleWorkspace, getPathByPlatform} from '@/helpers/workspace';
-import {showInputBox, showQuickPick} from '@/helpers/userInteraction';
+import {showQuickPick} from '@/helpers/userInteraction';
 import {Telemetry} from '@/TelemetryClient';
 
 export namespace DebuggerCommands {
@@ -29,28 +29,17 @@ export namespace DebuggerCommands {
 
     // const workspaceFolder = workspace.getWorkspaceFolder(workspaceUri);
 
-    if (debugNetwork.isLocalNetwork()) {
-      // if local service then provide last transactions to choose
-      const transactionProvider = new TransactionProvider(web3, contractBuildDir);
-      const txHashesAsQuickPickItems = await getQuickPickItems(transactionProvider);
+    const transactionProvider = new TransactionProvider(web3, contractBuildDir);
+    const txHashesAsQuickPickItems = await getQuickPickItems(transactionProvider);
 
-      const txHashSelection = await showQuickPick(txHashesAsQuickPickItems, {
-        ignoreFocusOut: true,
-        placeHolder: 'Enter the transaction hash to debug',
-      });
+    const txHashSelection = await showQuickPick(txHashesAsQuickPickItems, {
+      ignoreFocusOut: true,
+      placeHolder: 'Enter the transaction hash to debug',
+    });
 
-      const txHash = txHashSelection.detail || txHashSelection.label;
+    const txHash = txHashSelection.detail || txHashSelection.label;
 
-      await startDebugging(txHash, workingDirectory, providerUrl);
-    } else {
-      // if remote network then require txHash
-      const placeHolder = 'Type the transaction hash you want to debug (0x...)';
-      const txHash = await showInputBox({placeHolder});
-
-      if (txHash) {
-        await startDebugging(txHash, workingDirectory, providerUrl);
-      }
-    }
+    await startDebugging(txHash, workingDirectory, providerUrl);
   }
 }
 
@@ -66,11 +55,7 @@ async function getQuickPickItems(txProvider: TransactionProvider) {
   });
 }
 
-export function generateDebugAdapterConfig(
-  txHash: string,
-  workingDirectory: string,
-  providerUrl: string
-): DebugConfiguration {
+function generateDebugAdapterConfig(txHash: string, workingDirectory: string, providerUrl: string): DebugConfiguration {
   return {
     files: [],
     name: 'Debug Transactions',

--- a/src/debugAdapter/debugNetwork.ts
+++ b/src/debugAdapter/debugNetwork.ts
@@ -37,15 +37,6 @@ export class DebugNetwork {
     return this._networkForDebug;
   }
 
-  // Port and host are defined
-  public isLocalNetwork() {
-    if (!this._networkForDebug || !this._networkForDebug.options) {
-      throw new Error('Network is not defined. Try to call this.load()');
-    }
-    const options = this._networkForDebug.options;
-    return !!(options.host && options.port);
-  }
-
   private async loadConfiguration(): Promise<IConfiguration> {
     const configuration = await this._basedConfig!.getConfiguration(this.workingDirectory);
 

--- a/src/debugAdapter/models/debuggerTypes.ts
+++ b/src/debugAdapter/models/debuggerTypes.ts
@@ -25,9 +25,10 @@ export namespace DebuggerTypes {
     trace?: boolean;
     host?: string;
     txHash: string;
-    files: string[];
+    files?: string[];
     workingDirectory: string;
     providerUrl: string;
+    fetchExternal?: boolean;
   }
 
   export class LaunchedEvent implements DebugProtocol.Event {

--- a/src/helpers/uriHandlerController.ts
+++ b/src/helpers/uriHandlerController.ts
@@ -17,9 +17,14 @@ export class UriHandlerController implements UriHandler {
     try {
       // Gets the command name
       const command = uri.path.replace('/', '');
+      const searchParams = new URLSearchParams(uri.query);
 
       // Gets the configuration arguments
-      const debugConfig = JSON.parse(uri.query) as TDebugInformation;
+      const debugConfig: TDebugInformation = {
+        txHash: searchParams.get('txHash')!,
+        workingDirectory: searchParams.get('workingDirectory')!,
+        providerUrl: searchParams.get('providerUrl')!,
+      };
 
       // Checks what kind of command it will need to execute
       switch (command) {

--- a/src/helpers/uriHandlerController.ts
+++ b/src/helpers/uriHandlerController.ts
@@ -54,7 +54,7 @@ export class UriHandlerController implements UriHandler {
         txHash: searchParams.get('txHash')!,
         workingDirectory: searchParams.get('workingDirectory')!,
         providerUrl: searchParams.get('providerUrl')!,
-        fetchExternal: Boolean(searchParams.get('fetchExternal')!),
+        fetchExternal: searchParams.get('fetchExternal')! === 'true',
       };
 
       // Checks the command and executes the corresponding action.

--- a/src/helpers/uriHandlerController.ts
+++ b/src/helpers/uriHandlerController.ts
@@ -2,39 +2,75 @@ import {startDebugging} from '@/commands';
 import {Constants} from '@/Constants';
 import {Uri, UriHandler, window} from 'vscode';
 
+/**
+ * This type of URI handler is used to handle the `truffle-vscode` URI scheme.
+ */
 type TDebugInformation = {
+  /**
+   * The transaction hash to debug.
+   */
   txHash: string;
+
+  /**
+   * The working directory of the project.
+   */
   workingDirectory: string;
+
+  /**
+   * The network provider url.
+   */
   providerUrl: string;
+
+  /**
+   * The fetch external contracts flag.
+   */
+  fetchExternal: boolean;
 };
 
+/**
+ * This enum is used to identify the different types of commands that can be executed.
+ */
 enum Commands {
+  /**
+   * The command to start the debugger.
+   */
   debug = 'debug',
 }
 
 export class UriHandlerController implements UriHandler {
+  /**
+   * This function is responsible for handling the `truffle-vscode` protocol callings.
+   *
+   * @param uri The URI to handle.
+   */
   async handleUri(uri: Uri): Promise<void> {
     try {
-      // Gets the command name
+      // Parse the URI to get the command and the parameters.
       const command = uri.path.replace('/', '');
       const searchParams = new URLSearchParams(uri.query);
 
-      // Gets the configuration arguments
+      // Convert the URI parameters to a TDebugInformation object.
       const debugConfig: TDebugInformation = {
         txHash: searchParams.get('txHash')!,
         workingDirectory: searchParams.get('workingDirectory')!,
         providerUrl: searchParams.get('providerUrl')!,
+        fetchExternal: Boolean(searchParams.get('fetchExternal')!),
       };
 
-      // Checks what kind of command it will need to execute
+      // Checks the command and executes the corresponding action.
       switch (command) {
         case Commands.debug:
-          // Calls the debugger
-          await startDebugging(debugConfig.txHash, debugConfig.workingDirectory, debugConfig.providerUrl);
+          // Calls the debugger with the given parameters.
+          await startDebugging(
+            debugConfig.txHash,
+            debugConfig.workingDirectory,
+            debugConfig.providerUrl,
+            debugConfig.fetchExternal
+          );
           break;
       }
     } catch (error) {
-      // Displays a message if the command or arguments are badly formatted
+      // Display an error message if something went wrong.
       window.showErrorMessage(Constants.errorMessageStrings.UriHandlerError);
     }
   }

--- a/src/helpers/uriHandlerController.ts
+++ b/src/helpers/uriHandlerController.ts
@@ -1,32 +1,7 @@
 import {startDebugging} from '@/commands';
 import {Constants} from '@/Constants';
+import {DebuggerTypes} from '@/debugAdapter/models/debuggerTypes';
 import {Uri, UriHandler, window} from 'vscode';
-
-/**
- * This type of URI handler is used to handle the `truffle-vscode` URI scheme.
- */
-type TDebugInformation = {
-  /**
-   * The transaction hash to debug.
-   */
-  txHash: string;
-
-  /**
-   * The working directory of the project.
-   */
-  workingDirectory: string;
-
-  /**
-   * The network provider url.
-   */
-  providerUrl: string;
-
-  /**
-   * The fetch external contracts flag.
-   */
-  fetchExternal: boolean;
-};
-
 /**
  * This enum is used to identify the different types of commands that can be executed.
  */
@@ -50,7 +25,7 @@ export class UriHandlerController implements UriHandler {
       const searchParams = new URLSearchParams(uri.query);
 
       // Convert the URI parameters to a TDebugInformation object.
-      const debugConfig: TDebugInformation = {
+      const launchRequest: DebuggerTypes.ILaunchRequestArguments = {
         txHash: searchParams.get('txHash')!,
         workingDirectory: searchParams.get('workingDirectory')!,
         providerUrl: searchParams.get('providerUrl')!,
@@ -62,10 +37,10 @@ export class UriHandlerController implements UriHandler {
         case Commands.debug:
           // Calls the debugger with the given parameters.
           await startDebugging(
-            debugConfig.txHash,
-            debugConfig.workingDirectory,
-            debugConfig.providerUrl,
-            debugConfig.fetchExternal
+            launchRequest.txHash,
+            launchRequest.workingDirectory,
+            launchRequest.providerUrl,
+            launchRequest.fetchExternal!
           );
           break;
       }

--- a/test/commands/DebuggerCommands.test.ts
+++ b/test/commands/DebuggerCommands.test.ts
@@ -67,18 +67,4 @@ describe('DebuggerCommands unit tests', () => {
     assert.strictEqual(mockGetTxInfos.calledOnce, true, 'getTransactionsInfo should be called');
     assert.strictEqual(createQuickPickFn.called, true, 'createQuickPic should be called');
   });
-
-  it('should show inputBox when debugNetwork.isLocalNetwork() is false', async () => {
-    // Arrange
-    sinon.stub(DebugNetwork.prototype, 'isLocalNetwork').returns(false);
-    const showInputBoxFn = sinon.stub(userInteraction, 'showInputBox').resolves('');
-
-    // Act
-    await debugCommands.DebuggerCommands.startSolidityDebugger();
-
-    // Assert
-    assert.strictEqual(showInputBoxFn.called, true, 'showInputBox should be called');
-    assert.strictEqual(mockGetTxHashes.calledOnce, false, "getLastTransactionHashes shouldn't be called");
-    assert.strictEqual(mockGetTxInfos.calledOnce, false, "getTransactionsInfo shouldn't be called");
-  });
 });

--- a/test/commands/DebuggerCommands.test.ts
+++ b/test/commands/DebuggerCommands.test.ts
@@ -54,9 +54,8 @@ describe('DebuggerCommands unit tests', () => {
     sinon.restore();
   });
 
-  it('should generate and show quickPick when debugNetwork.isLocalNetwork() is true', async () => {
+  it('should generate and show quickPick when debugger is called', async () => {
     // Arrange
-    sinon.stub(DebugNetwork.prototype, 'isLocalNetwork').returns(true);
     const createQuickPickFn = sinon.stub(userInteraction, 'showQuickPick').resolves({} as QuickPickItem);
 
     // Act


### PR DESCRIPTION
## PR description

This PR contains some improvements to the routine responsible for handling the calls addressed to vscode protocol. It also fixes some bugs and implements a new parameter to the debuger configuration. Below is the list of changes:

### - Bug fix ###

I've made a simple modification to support windows command prompt calls. Command prompt does not support sending Json Objects on URL so I had to change the arguments from object to querystring params. Unfortunately, the Windows command prompt does not support sending an URL with Json Objects.

Before: `{"txHash":"0x97a81dbca1ea95263bb75b0147c99f263fe21cf702abe8974c310c9fa834d9b9","workingDirectory":"/Users/xhulz/Documents/xpto","providerUrl":"[http://127.0.0.1:8545"}](http://127.0.0.1:8545%22%7D/)`

Now: `"txHash=0x4d1f42a6096f82e01a680a7364e958f9214447473e025f8f00fe05314a4f6fb5&workingDirectory=%2FUsers%2Fxhulz%2FDocuments%2FCode%2Fboxes&providerUrl=http%3A%2F%2F127.0.0.1%3A8545"`

### Refactor ###

@acuarica I took the opportunity to fix those issues that you've pointed on the last PR #231 

### New parameter on debug configuration ###

@acuarica I've implemented a new parameter on querystring called `fetchExternal`. I built the changes and left a comment on `DebuggerCommand.ts` to handle this parameter, because it was hard coded to `false`

`// TODO: Add a way to select if the user wants to fetch external contracts`
`const fetchExternal = false;`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
