### PR TITLE
Update `@truffle/debugger` to remove `faker` in bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -822,7 +822,7 @@
     "@truffle/compile-solidity": "^6.0.31",
     "@truffle/config": "1.3.38",
     "@truffle/debug-utils": "^6.0.26",
-    "@truffle/debugger": "^10.0.14",
+    "@truffle/debugger": "^11.0.17",
     "@truffle/fetch-and-compile": "^0.5.19",
     "@truffle/resolver": "^9.0.4",
     "@truffle/workflow-compile": "^4.0.36",

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -93,7 +93,7 @@ export default class RuntimeInterface extends EventEmitter {
     Record<string, TranslatedResult> | any
   > {
     if (this._session) {
-      const variables = await this._session.variables({indicateUnknown: true});
+      const variables = await this._session.variables();
       return translateTruffleVariables(variables);
     } else {
       return Promise.resolve({});

--- a/src/debugAdapter/types/@truffle/debugger.d.ts
+++ b/src/debugAdapter/types/@truffle/debugger.d.ts
@@ -20,7 +20,7 @@ declare module '@truffle/debugger' {
     removeAllBreakpoints: () => Promise<void>;
     view: (selectors: any) => any;
     addBreakpoint: (breakPoint: any) => unknown;
-    variables: ({indicateUnknown: boolean}?) => Promise<any>;
+    variables: () => Promise<any>;
     continueUntilBreakpoint: () => Promise<void>;
     stepNext: () => Promise<void>;
     stepInto: () => Promise<void>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,15 +1010,6 @@
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@truffle/abi-utils@^0.2.14", "@truffle/abi-utils@^0.2.15":
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/@truffle/abi-utils/-/abi-utils-0.2.17.tgz#a234ff38a12e80a1342ea3d7193e9c3caaf5cc03"
-  integrity sha512-Lz8bDjEYInaesdpP3ENVnDkfSkEmrV2z9BNcIEQPQnqdB5x/H+rIrWGny7LV6rX3Kz3kAerF8eGBFh7Z/dEhZw==
-  dependencies:
-    change-case "3.0.2"
-    faker "5.5.3"
-    fast-check "3.1.1"
-
 "@truffle/abi-utils@^0.3.0", "@truffle/abi-utils@^0.3.2":
   version "0.3.2"
   resolved "https://registry.npmjs.org/@truffle/abi-utils/-/abi-utils-0.3.2.tgz"
@@ -1076,22 +1067,6 @@
   dependencies:
     cbor "^5.2.0"
 
-"@truffle/codec@^0.13.2":
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.13.3.tgz#cec94f10f73d13cf856f7ca63d300220502f55c0"
-  integrity sha512-RkbjTE2RuoShxalMqmOUEhxSTZcxeM4m8yLzMaQKvmEga+0b9Gpjn3wu9+3smnNRWC6T3q0AGsaBKt9FSiVGmg==
-  dependencies:
-    "@truffle/abi-utils" "^0.2.15"
-    "@truffle/compile-common" "^0.7.32"
-    big.js "^6.0.3"
-    bn.js "^5.1.3"
-    cbor "^5.1.0"
-    debug "^4.3.1"
-    lodash "^4.17.21"
-    semver "7.3.7"
-    utf8 "^3.0.0"
-    web3-utils "1.7.4"
-
 "@truffle/codec@^0.14.5":
   version "0.14.5"
   resolved "https://registry.npmjs.org/@truffle/codec/-/codec-0.14.5.tgz"
@@ -1144,14 +1119,6 @@
   version "0.8.1"
   resolved "https://registry.npmjs.org/@truffle/compile-common/-/compile-common-0.8.1.tgz"
   integrity sha512-7mzzG9Cfrn+fDT5Sqi7B6pccvIIV5w/GM8/56YgnjysbDzy5aZ6mv0fe37ZbcznEVQ35NJjBy+lEr/ozOGXwQA==
-  dependencies:
-    "@truffle/error" "^0.1.1"
-    colors "1.4.0"
-
-"@truffle/compile-common@^0.7.32":
-  version "0.7.34"
-  resolved "https://registry.yarnpkg.com/@truffle/compile-common/-/compile-common-0.7.34.tgz#c5b3e31cc716af91330f6a66f4dde1dbc491a58b"
-  integrity sha512-NA8HuTCw6pgTpCyMd7M70Ii8AVD921R95UnXB3dwVWwEyV1OksaAsTKfdLxeLnFR4ISkK6o2NqpFb/lM3+V+9w==
   dependencies:
     "@truffle/error" "^0.1.1"
     colors "1.4.0"
@@ -1550,14 +1517,14 @@
     debug "^4.3.1"
     highlightjs-solidity "^2.0.5"
 
-"@truffle/debugger@^10.0.14":
-  version "10.0.17"
-  resolved "https://registry.yarnpkg.com/@truffle/debugger/-/debugger-10.0.17.tgz#4b7c4773635be8d0a99a2e2184989883f0ac6030"
-  integrity sha512-z119CdSa2pjfchxU7KUeR8yxuTSfayeo6MGrMo9pCTsoIb2/SjPgIz3kiObLgumi36Pi+gfjXaHmvnCtaYwBNA==
+"@truffle/debugger@^11.0.17":
+  version "11.0.17"
+  resolved "https://registry.yarnpkg.com/@truffle/debugger/-/debugger-11.0.17.tgz#5729258bcde6e11f754eeed8f7158c2cf32ef587"
+  integrity sha512-R38c1MFZTPDEdvFgJhSE11zGCW+IMdlQknT8LdpJBQjmamqGyWY1QUIpjX2IwQalbJ3TWPckzy8Qcqu5zeSOhw==
   dependencies:
-    "@truffle/abi-utils" "^0.2.14"
-    "@truffle/codec" "^0.13.2"
-    "@truffle/source-map-utils" "^1.3.88"
+    "@truffle/abi-utils" "^0.3.4"
+    "@truffle/codec" "^0.14.9"
+    "@truffle/source-map-utils" "^1.3.101"
     bn.js "^5.1.3"
     debug "^4.3.1"
     json-pointer "^0.6.1"
@@ -1566,7 +1533,7 @@
     redux "^3.7.2"
     redux-saga "1.0.0"
     reselect-tree "^1.3.7"
-    semver "^7.3.4"
+    semver "7.3.7"
     web3 "1.7.4"
     web3-eth-abi "1.7.4"
 
@@ -1888,7 +1855,19 @@
     node-abort-controller "^3.0.1"
     web3-utils "1.7.4"
 
-"@truffle/source-map-utils@^1.3.88", "@truffle/source-map-utils@^1.3.96":
+"@truffle/source-map-utils@^1.3.101":
+  version "1.3.101"
+  resolved "https://registry.yarnpkg.com/@truffle/source-map-utils/-/source-map-utils-1.3.101.tgz#20701b80a22d5e5f06e9e88bf0d8d07f683c6f25"
+  integrity sha512-jcleQpwqbOCTjseODTrTc4pPLfEhWDwYdoz5GUOiTJF6+nfqrwt9Z2nAauIuKp4l7AoVnzbOPkr8ycs+fjdpdA==
+  dependencies:
+    "@truffle/code-utils" "^3.0.0"
+    "@truffle/codec" "^0.14.9"
+    debug "^4.3.1"
+    json-pointer "^0.6.1"
+    node-interval-tree "^1.3.3"
+    web3-utils "1.7.4"
+
+"@truffle/source-map-utils@^1.3.96":
   version "1.3.96"
   resolved "https://registry.yarnpkg.com/@truffle/source-map-utils/-/source-map-utils-1.3.96.tgz#c9d656857a090819410128497e76e8699bfd10bb"
   integrity sha512-34UViOH9HyO35zNjZjxfkgMgKHSi+RCI1VOldreirFP/MCeowYtT9mqZwMCDagRsSNJf2SYhwVueSEKq9l+Chg==
@@ -3800,7 +3779,7 @@ caw@^2.0.1:
     tunnel-agent "^0.6.0"
     url-to-options "^1.0.1"
 
-cbor@^5.1.0, cbor@^5.2.0:
+cbor@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.2.0.tgz#4cca67783ccd6de7b50ab4ed62636712f287a67c"
   integrity sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==
@@ -5680,11 +5659,6 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-
-faker@5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-check@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## PR description

This PR closes #263. After updating both `package.json` and `yarn.lock`, `faker` is not included anymore in the bundle. Run the following to check that `faker` was effectively removed

```sh
$ yarn webpack:dev
$ cat out/src/extension.js | grep faker | wc -l
       1
```

this result is just metadata
```
module.exports = JSON.parse('{[...]"devDependencies":{"@types/faker":"^5.1.2"[...]}');
```

and 

```sh
$ yarn why faker
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "faker"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
error We couldn't find a match!
✨  Done in 0.32s.
```

Debugger typings must be updated since bumping to `11.0.17` is breaking change as described here https://github.com/trufflesuite/truffle/pull/5286#issuecomment-1184020915 and https://github.com/trufflesuite/truffle/pull/5286#issuecomment-1184046954.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
