### PR TITLE
Invalidate `require` cache of `truffle-config.js`

### DIFF
--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -147,13 +147,13 @@ export default class RuntimeInterface extends EventEmitter {
       /**/
     }
 
-    // Retreives the truffle configuration file
+    // Retrieves the truffle configuration file
     const config = Config.detect({workingDirectory: args.workingDirectory});
 
     // Validate the network parameter
     RuntimeInterface.validateNetwork(config, args);
 
-    // Retreives the environment configuration
+    // Retrieves the environment configuration
     await Environment.detect(config);
 
     // Gets the contracts compilation

--- a/src/debugAdapter/runtimeInterface.ts
+++ b/src/debugAdapter/runtimeInterface.ts
@@ -12,6 +12,7 @@ import {mkdirpSync, writeFileSync} from 'fs-extra';
 import {fetchAndCompileForDebugger} from '@truffle/fetch-and-compile';
 import Config from '@truffle/config';
 import {Environment} from '@truffle/environment';
+import Module from 'module';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -136,6 +137,16 @@ export default class RuntimeInterface extends EventEmitter {
    * @returns
    */
   public async attach(args: Required<DebuggerTypes.DebugArgs>): Promise<void> {
+    try {
+      const originalRequire = eval('require');
+      // Mimics the behavior of `Config.detect` until https://github.com/trufflesuite/truffle/pull/5728 gets merged.
+      const file = path.join(args.workingDirectory, 'truffle-config.js');
+      const resolvedFileName = (Module as any)._resolveFilename(file, module);
+      delete originalRequire.cache[resolvedFileName];
+    } catch {
+      /**/
+    }
+
     // Retreives the truffle configuration file
     const config = Config.detect({workingDirectory: args.workingDirectory});
 


### PR DESCRIPTION
## PR description

This PR closes #262. Essentially duplicates the changes made in https://github.com/trufflesuite/truffle/pull/5728. This means that if https://github.com/trufflesuite/truffle/pull/5728 gets merged we can revert the changes of this PR.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
