### PR TITLE
Declare `network` option in launch configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -603,6 +603,11 @@
                 "description": "Provider's URL of the Ethereum network to connect to.",
                 "default": "http://127.0.0.1:8545"
               },
+              "network": {
+                "type": "string",
+                "description": "Name of the Ethereum network to connect to. The network name should be a key in the `networks` object in your Truffle config file.",
+                "default": "development"
+              },
               "disableFetchExternal": {
                 "type": "boolean",
                 "description": "When set, do not try to fetch external contract sources when debugging a forked network instance. When the network is not being forked, this flag is ignored.",
@@ -637,6 +642,21 @@
               "files": [],
               "workingDirectory": "^\"\\${workspaceFolder}\"",
               "providerUrl": "http://127.0.0.1:8545",
+              "disableFetchExternal": false
+            }
+          },
+          {
+            "label": "Truffle - Debugger Launch using config network",
+            "description": "Runs the Truffle debugger (truffle) and attaches to a TestRPC instance",
+            "body": {
+              "type": "truffle",
+              "request": "launch",
+              "name": "Debug Transaction with Truffle",
+              "stopOnEntry": false,
+              "txHash": "0x",
+              "files": [],
+              "workingDirectory": "^\"\\${workspaceFolder}\"",
+              "network": "development",
               "disableFetchExternal": false
             }
           }

--- a/package.json
+++ b/package.json
@@ -631,7 +631,7 @@
         "configurationSnippets": [
           {
             "label": "Truffle - Debugger Launch",
-            "description": "Runs the Truffle debugger (truffle) and attaches to a TestRPC instance",
+            "description": "Runs the Truffle debugger (truffle) and attaches to a Ganache instance",
             "body": {
               "type": "truffle",
               "request": "launch",
@@ -646,7 +646,7 @@
           },
           {
             "label": "Truffle - Debugger Launch using config network",
-            "description": "Runs the Truffle debugger (truffle) and attaches to a TestRPC instance",
+            "description": "Runs the Truffle debugger (truffle) and attaches to a Ganache instance",
             "body": {
               "type": "truffle",
               "request": "launch",

--- a/package.json
+++ b/package.json
@@ -569,8 +569,7 @@
           "launch": {
             "required": [
               "txHash",
-              "workingDirectory",
-              "providerUrl"
+              "workingDirectory"
             ],
             "properties": {
               "stopOnEntry": {


### PR DESCRIPTION
## PR description

This PR declares the newly added `network` option https://github.com/trufflesuite/vscode-ext/pull/261 in the [launch configuration](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations).

https://user-images.githubusercontent.com/4592980/203780382-c6bca2b8-8633-4baf-bbb2-7c685775acdd.mp4

Moreover, it includes a new configuration snippet that uses the `network` option instead of `providerUrl`

https://user-images.githubusercontent.com/4592980/203783922-ad44b98a-4fbe-4ee2-87dc-2d1e7c9a26b2.mp4

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
