### PR TITLE
Remove `devtool` from production bundle

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -28,11 +28,5 @@ jobs:
       - name: Tests
         run: yarn test:int
 
-      # Not sure why, but setting `devtool: false` in `webpack.prod.js` with no increased memory gives
-      # Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory
-      #
-      # Increase memory with https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
       - name: Build smoke check package
         run: yarn package
-        # env:
-        #   NODE_OPTIONS: --max_old_space_size=4096

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: 'yarn'
@@ -30,5 +30,5 @@ jobs:
 
       - name: Build smoke check package
         run: yarn package
-        env:
-          NODE_OPTIONS: --max_old_space_size=4096
+        # env:
+        # NODE_OPTIONS: --max_old_space_size=4096

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Tests
         run: yarn test:int
+
+      - name: Package
+        run: yarn package

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -28,7 +28,11 @@ jobs:
       - name: Tests
         run: yarn test:int
 
+      # Not sure why, but setting `devtool: false` in `webpack.prod.js` with no increased memory gives
+      # Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory
+      #
+      # Increase memory with https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
       - name: Build smoke check package
         run: yarn package
-        # env:
-        # NODE_OPTIONS: --max_old_space_size=4096
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -34,5 +34,5 @@ jobs:
       # Increase memory with https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
       - name: Build smoke check package
         run: yarn package
-        env:
-          NODE_OPTIONS: --max_old_space_size=4096
+        # env:
+        #   NODE_OPTIONS: --max_old_space_size=4096

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -28,5 +28,7 @@ jobs:
       - name: Tests
         run: yarn test:int
 
-      - name: Package
+      - name: Build smoke check package
         run: yarn package
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,7 +3,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
-  devtool: 'eval',
+  devtool: false,
   optimization: {
     minimize: true,
   },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,7 +3,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
-  devtool: false,
+  devtool: 'eval',
   optimization: {
     minimize: true,
   },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,6 +3,8 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
+  // By removing source map generation, we reduce bundle size by 50%.
+  // See https://webpack.js.org/configuration/devtool/ for more details.
   devtool: false,
   optimization: {
     minimize: true,


### PR DESCRIPTION
## PR description

This PR is a follow-up of https://github.com/trufflesuite/vscode-ext/pull/245. The main goal is to improve performance, more specifically, when activating the extension by reducing package size. See https://github.com/trufflesuite/vscode-ext/pull/245#issuecomment-1326630850 for more details.

Moreover, it builds the `vsix` package in CI as a smoke check.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
