### PR TITLE
Remove `prettier` from bundle

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,6 +30,9 @@ module.exports = {
       // See PR https://github.com/trufflesuite/vscode-ext/pull/261 for more details.
       return callback(null, 'require ("' + request + '")');
     } else if (/^prettier$/.test(request)) {
+      // `prettier` is actually not used by the extension.
+      // It's included because there is transitive dependency through `@truffle#resolver#abi-to-sol#prettier`.
+      // See PR https://github.com/trufflesuite/vscode-ext/pull/270 for more details.
       return callback(null, 'require ("' + request + '")');
     } else if (/^electron$/.test(request)) {
       return callback(null, 'require ("' + request + '")');

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -29,6 +29,8 @@ module.exports = {
       // Thus, setting `ganache` as external allows to exclude it from the bundle.
       // See PR https://github.com/trufflesuite/vscode-ext/pull/261 for more details.
       return callback(null, 'require ("' + request + '")');
+    } else if (/^prettier$/.test(request)) {
+      return callback(null, 'require ("' + request + '")');
     } else if (/^electron$/.test(request)) {
       return callback(null, 'require ("' + request + '")');
     }


### PR DESCRIPTION
## PR description

This PR removes the `prettier` package from the extension bundle. `prettier` is actually not used by the extension. However there is a transitive dependency from `@truffle/resolver`

```sh
$ yarn why prettier
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "prettier"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "prettier@2.7.1"
info Has been hoisted to "prettier"
info Reasons this module exists
   - Specified in "devDependencies"
   - Hoisted from "@truffle#resolver#abi-to-sol#prettier"
info Disk size without dependencies: "15.16MB"
info Disk size with unique dependencies: "15.16MB"
info Disk size with transitive dependencies: "15.16MB"
info Number of shared dependencies: 0
✨  Done in 0.31s.
```

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
