### PR TITLE
Allow Node v18 in Required Apps

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -104,7 +104,7 @@ export class Constants {
       min: '1.0.17',
     },
     [RequiredApps.node]: {
-      max: '17.0.0',
+      max: '19.0.0',
       min: '14.0.0',
     },
     [RequiredApps.npm]: {


### PR DESCRIPTION
## PR description

Both Truffle and Ganache allows to use Node 18. This PR allows the user to use Node 18 as well.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
