### PR TITLE
Clarify Ganache CLI usage in `Requirements Page`

### DIFF
--- a/resources/welcome/prereqs.html
+++ b/resources/welcome/prereqs.html
@@ -76,8 +76,8 @@
             <p>
               At this time, while the extension is still in public-preview, you
               will also need to install the Truffle Suite of developer tools.
-              Click the links below to install the Truffle tools directly from
-              this extension
+              Click the links below to install Truffle Suite and Ganache CLI
+              directly from this extension
             </p>
             <div class="required">
               <div id="truffle" class="required-app disabled">
@@ -109,9 +109,9 @@
                 <a
                   id="installGanache"
                   class="spinner action"
-                  title="Install Ganache"
+                  title="Install Ganache CLI"
                 >
-                  <span>Install Ganache</span>
+                  <span>Install Ganache CLI</span>
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## PR description

This PR clarifies that the extension depends on Ganache CLI, as opposed to Ganache UI., in the `Requirements Page`.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
