### PR TITLE
Add Telemetry event to `vscode://` URI handler

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -606,7 +606,6 @@ export class Constants {
     DashboardVersionError: 'Please upgrade to the latest version of Truffle to use this feature',
     FetchingBoxesHasFailed: 'An error occurred while fetching boxes',
     ContractFolderNotExists: 'There is no contract directory in this workspace',
-    UriHandlerError: 'Badly formatted. Ensure that the command and arguments are described correctly',
   };
 
   public static informationMessage = {

--- a/src/helpers/uriHandlerController.ts
+++ b/src/helpers/uriHandlerController.ts
@@ -1,5 +1,5 @@
 import {startDebugging} from '@/commands';
-import {Constants} from '@/Constants';
+import {Telemetry} from '@/TelemetryClient';
 import {Uri, UriHandler, window} from 'vscode';
 
 /**
@@ -42,11 +42,13 @@ export class UriHandlerController implements UriHandler {
           break;
         }
         default:
-          window.showWarningMessage(`Unrecognized action to handle \`${command}\``);
+          void window.showWarningMessage(`Unrecognized action to handle \`${command}\``);
       }
+
+      Telemetry.sendEvent('UriHandler.handleUri', {command});
     } catch (error) {
       // Display an error message if something went wrong.
-      window.showErrorMessage(Constants.errorMessageStrings.UriHandlerError);
+      void window.showErrorMessage('Badly formatted. Ensure that the command and arguments are described correctly');
     }
   }
 }

--- a/src/helpers/uriHandlerController.ts
+++ b/src/helpers/uriHandlerController.ts
@@ -19,36 +19,31 @@ export class UriHandlerController implements UriHandler {
    * @param uri The URI to handle.
    */
   async handleUri(uri: Uri): Promise<void> {
-    try {
-      // Parse the URI to get the command and the parameters.
-      const command = uri.path.replace('/', '');
-      const searchParams = new URLSearchParams(uri.query);
+    // Parse the URI to get the command and the parameters.
+    const command = uri.path.replace('/', '');
+    const searchParams = new URLSearchParams(uri.query);
 
-      // Checks the command and executes the corresponding action.
-      switch (command) {
-        case Commands.debug: {
-          // Convert the URI parameters to a `DebugArgs` object.
-          // The `??` operator converts `null` to `undefined`.
-          const args = {
-            txHash: searchParams.get('txHash') ?? undefined,
-            workingDirectory: searchParams.get('workingDirectory') ?? undefined,
-            providerUrl: searchParams.get('providerUrl') ?? undefined,
-            network: searchParams.get('network') ?? undefined,
-            disableFetchExternal: !!searchParams.get('disableFetchExternal'),
-          };
+    // Checks the command and executes the corresponding action.
+    switch (command) {
+      case Commands.debug: {
+        // Convert the URI parameters to a `DebugArgs` object.
+        // The `??` operator converts `null` to `undefined`.
+        const args = {
+          txHash: searchParams.get('txHash') ?? undefined,
+          workingDirectory: searchParams.get('workingDirectory') ?? undefined,
+          providerUrl: searchParams.get('providerUrl') ?? undefined,
+          network: searchParams.get('network') ?? undefined,
+          disableFetchExternal: !!searchParams.get('disableFetchExternal'),
+        };
 
-          // Calls the debugger with the given parameters.
-          await startDebugging(args);
-          break;
-        }
-        default:
-          void window.showWarningMessage(`Unrecognized action to handle \`${command}\``);
+        // Calls the debugger with the given parameters.
+        await startDebugging(args);
+        break;
       }
-
-      Telemetry.sendEvent('UriHandler.handleUri', {command});
-    } catch (error) {
-      // Display an error message if something went wrong.
-      void window.showErrorMessage('Badly formatted. Ensure that the command and arguments are described correctly');
+      default:
+        void window.showWarningMessage(`Unrecognized action to handle \`${command}\``);
     }
+
+    Telemetry.sendEvent('UriHandler.handleUri', {command});
   }
 }


### PR DESCRIPTION
## PR description

This PR closes #281.

Only the URI's path, _i.e._, the `command`, is being sent as a additional property. This is to avoid sending any potential private user data.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
