### PR TITLE
refactor: rename the Dashboard's Copy RPC Endpoint Address command

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
       },
       {
         "command": "truffle-vscode.views.dashboard.copyRPCEndpointAddress",
-        "title": "Copy RPC Endpoint Address",
+        "title": "Copy Dashboard RPC Endpoint Address",
         "category": "Truffle"
       },
       {


### PR DESCRIPTION
## PR description

Renamed the 'truffle-vscode.views.dashboard.copyRPCEndpointAddress' command title to: 'Copy Dashboard RPC Endpoint Address'.

## Documentation

- [ x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
